### PR TITLE
Change ids to string and selector bug fixes

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.6.0-beta.8",
+  "version": "0.6.0-beta.9",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clarity",
   "private": true,
-  "version": "0.6.0-beta.8",
+  "version": "0.6.0-beta.9",
   "repository": "https://github.com/microsoft/clarity.git",
   "author": "Sarvesh Nagpal <sarveshn@microsoft.com>",
   "license": "MIT",

--- a/packages/clarity-decode/package.json
+++ b/packages/clarity-decode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-decode",
-  "version": "0.6.0-beta.8",
+  "version": "0.6.0-beta.9",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-js": "^0.6.0-beta.8"
+    "clarity-js": "^0.6.0-beta.9"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.1.0",

--- a/packages/clarity-decode/src/data.ts
+++ b/packages/clarity-decode/src/data.ts
@@ -77,9 +77,9 @@ export function envelope(tokens: Data.Token[]): Data.Envelope {
         sequence: tokens[1] as number,
         start: tokens[2] as number,
         duration: tokens[3] as number,
-        projectId: tokens[4] as number,
-        userId: tokens[5] as number,
-        sessionId: tokens[6] as number,
+        projectId: tokens[4] as string,
+        userId: tokens[5] as string,
+        sessionId: tokens[6] as string,
         pageNum: tokens[7] as number,
         upload: tokens[8] as Data.Upload,
         end: tokens[9] as Data.BooleanFlag

--- a/packages/clarity-decode/src/interaction.ts
+++ b/packages/clarity-decode/src/interaction.ts
@@ -31,7 +31,8 @@ export function decode(tokens: Data.Token[]): InteractionEvent {
                 text: tokens[8] as string,
                 link: tokens[9] as string,
                 hash: tokens[10] as number,
-                region: tokens.length > 11 ? tokens[11] as number : null
+                selector: tokens[11] as string,
+                region: tokens.length > 12 ? tokens[12] as number : null
             };
             return { time, event, data: clickData };
             break;

--- a/packages/clarity-decode/src/interaction.ts
+++ b/packages/clarity-decode/src/interaction.ts
@@ -31,8 +31,7 @@ export function decode(tokens: Data.Token[]): InteractionEvent {
                 text: tokens[8] as string,
                 link: tokens[9] as string,
                 hash: tokens[10] as number,
-                selector: tokens[11] as string,
-                region: tokens.length > 12 ? tokens[12] as number : null
+                region: tokens.length > 11 ? tokens[11] as number : null
             };
             return { time, event, data: clickData };
             break;

--- a/packages/clarity-decode/src/layout.ts
+++ b/packages/clarity-decode/src/layout.ts
@@ -116,6 +116,7 @@ function process(node: any[] | number[], tagIndex: number): DomData {
     if (selector.length > 0) {
         output.selector = selector;
         output.hash = helper.hash(selector);
+        hashes[output.id] = selector;
     }
 
     if (hasAttribute) { output.attributes = attributes; }

--- a/packages/clarity-decode/types/layout.d.ts
+++ b/packages/clarity-decode/types/layout.d.ts
@@ -22,5 +22,4 @@ export interface DomData {
     hash: number;
     attributes?: Layout.Attributes;
     value?: string;
-    next?: number; /* deprecated since v0.4.5 */
 }

--- a/packages/clarity-devtools/package.json
+++ b/packages/clarity-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-devtools",
-  "version": "0.6.0-beta.8",
+  "version": "0.6.0-beta.9",
   "private": true,
   "description": "Adds Clarity debugging support to browser devtools",
   "author": "Microsoft Corp.",
@@ -24,9 +24,9 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.6.0-beta.8",
-    "clarity-js": "^0.6.0-beta.8",
-    "clarity-visualize": "^0.6.0-beta.8"
+    "clarity-decode": "^0.6.0-beta.9",
+    "clarity-js": "^0.6.0-beta.9",
+    "clarity-visualize": "^0.6.0-beta.9"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^7.1.3",

--- a/packages/clarity-devtools/src/content.ts
+++ b/packages/clarity-devtools/src/content.ts
@@ -27,7 +27,7 @@ function activate(): void {
         regions,
         content: items.clarity.showText,
         upload,
-        projectId: 1051133397904 // parseInt("devtools", 36);
+        projectId: "devtools"
       });
       // Send a custom event
       clarity.event("Developer Tools", "start");

--- a/packages/clarity-devtools/src/panel.ts
+++ b/packages/clarity-devtools/src/panel.ts
@@ -29,7 +29,7 @@ background.onMessage.addListener(function(message: any): void {
         if (decoded.envelope.sequence === 1) { reset(decoded.envelope); }
         eJson.push(JSON.parse(message.payload));
         dJson.push(decoded);
-        id = `${envelope.sessionId.toString(36)}-${envelope.pageNum.toString(36)}`;
+        id = `${envelope.sessionId}-${envelope.pageNum.toString(36)}`;
         let merged = visualize.merge([decoded]);
         events = events.concat(merged.events).sort(sort);
         visualize.dom(merged.dom);

--- a/packages/clarity-devtools/static/manifest.json
+++ b/packages/clarity-devtools/static/manifest.json
@@ -3,7 +3,7 @@
   "name": "Clarity Developer Tools",
   "description": "Get insights about how customers use your website.",
   "version": "0.6.0",
-  "version_name": "0.6.0-beta.8",
+  "version_name": "0.6.0-beta.9",
   "minimum_chrome_version": "50",
   "devtools_page": "devtools.html",
   "icons": {

--- a/packages/clarity-js/package.json
+++ b/packages/clarity-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.6.0-beta.8",
+  "version": "0.6.0-beta.9",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/packages/clarity-js/src/core/config.ts
+++ b/packages/clarity-js/src/core/config.ts
@@ -11,7 +11,7 @@ let config: Config = {
     unmask: [],
     regions: {},
     cookies: [],
-    url: "",
+    report: null,
     upload: null
 };
 

--- a/packages/clarity-js/src/core/index.ts
+++ b/packages/clarity-js/src/core/index.ts
@@ -2,6 +2,7 @@ import { Config } from "@clarity-types/core";
 import { Constant } from "@clarity-types/data";
 import configuration from "@src/core/config";
 import * as event from "@src/core/event";
+import * as report from "@src/core/report";
 import * as task from "@src/core/task";
 import * as time from "@src/core/time";
 import * as clarity from "@src/clarity";
@@ -14,9 +15,11 @@ export function start(): void {
     time.start();
     task.reset();
     event.reset();
+    report.reset();
 }
 
 export function stop(): void {
+    report.reset();
     event.reset();
     task.reset();
     time.stop();

--- a/packages/clarity-js/src/core/report.ts
+++ b/packages/clarity-js/src/core/report.ts
@@ -1,0 +1,23 @@
+import { Report } from "@clarity-types/core";
+import config from "@src/core/config";
+import { data } from "@src/data/metadata";
+
+let history: string[];
+
+export function reset(): void {
+    history = [];
+}
+
+export function report(message: string): void {
+    // Do not report the same message twice for the same page
+    if (history && history.indexOf(message) === -1) {
+        const url = config.report;
+        if (url && url.length > 0) {
+            let payload = JSON.stringify({m: message, p: data.projectId, u: data.userId, s: data.sessionId, n: data.pageNum} as Report);
+            let xhr = new XMLHttpRequest();
+            xhr.open("POST", url);
+            xhr.send(payload);
+            history.push(message);
+        }
+    }
+}

--- a/packages/clarity-js/src/core/version.ts
+++ b/packages/clarity-js/src/core/version.ts
@@ -1,2 +1,2 @@
-let version = "0.6.0-b8";
+let version = "0.6.0-b9";
 export default version;

--- a/packages/clarity-js/src/data/limit.ts
+++ b/packages/clarity-js/src/data/limit.ts
@@ -1,5 +1,6 @@
 import { Check, Event, LimitData, Setting } from "@clarity-types/data";
 import * as clarity from "@src/clarity";
+import { report } from "@src/core/report";
 import { time } from "@src/core/time";
 import * as envelope from "@src/data/envelope";
 import encode from "./encode";
@@ -23,6 +24,7 @@ export function check(bytes: number): void {
 }
 
 export function trigger(reason: Check): void {
+    report(`Limit #${reason}`);
     data.check = reason;
     clarity.stop();
 }

--- a/packages/clarity-js/src/data/metadata.ts
+++ b/packages/clarity-js/src/data/metadata.ts
@@ -16,7 +16,7 @@ export function start(): void {
   // Populate ids for this page
   let s = session(ts);
   data = {
-    projectId: config.projectId || hash(location.host),
+    projectId: config.projectId || str(hash(location.host)),
     userId: user(),
     sessionId: s[0],
     pageNum: s[1]
@@ -62,6 +62,10 @@ export function consent(): void {
   }
 }
 
+function str(input: number): string {
+  return input.toString(36);
+}
+
 function track(): void {
   if (config.track) {
     let expiry = new Date();
@@ -72,15 +76,15 @@ function track(): void {
   }
 }
 
-function shortid(): number {
+function shortid(): string {
+  let id = Math.floor(Math.random() * Math.pow(2, 32));
   if (window && window.crypto && window.crypto.getRandomValues && Uint32Array) {
-    return window.crypto.getRandomValues(new Uint32Array(1))[0];
-  } else {
-    return Math.floor(Math.random() * Math.pow(2, 32));
+    id = window.crypto.getRandomValues(new Uint32Array(1))[0];
   }
+  return str(id);
 }
 
-function session(ts: number): number[] {
+function session(ts: number): [string, number] {
   let id = shortid();
   let count = 1;
   if (config.track && sessionStorage) {
@@ -88,7 +92,7 @@ function session(ts: number): number[] {
     if (value && value.indexOf(Constant.Separator) >= 0) {
       let parts = value.split(Constant.Separator);
       if (parts.length === 3 && ts - num(parts[1]) < Setting.SessionTimeout) {
-        id = num(parts[0]);
+        id = parts[0];
         count = num(parts[2]) + 1;
       }
     }
@@ -101,9 +105,9 @@ function num(string: string, base: number = 10): number {
   return parseInt(string, base);
 }
 
-function user(): number {
+function user(): string {
   let id = cookie(Constant.CookieKey);
-  return id && id.length > 0 ? num(id) : shortid();
+  return id && id.length > 0 ? id : shortid();
 }
 
 function cookie(key: string): string {

--- a/packages/clarity-js/src/interaction/click.ts
+++ b/packages/clarity-js/src/interaction/click.ts
@@ -1,4 +1,4 @@
-import { Event } from "@clarity-types/data";
+import { Constant, Event, Setting } from "@clarity-types/data";
 import { ClickState } from "@clarity-types/interaction";
 import { bind } from "@src/core/event";
 import { schedule } from "@src/core/task";
@@ -61,13 +61,25 @@ function handler(event: Event, root: Node, evt: MouseEvent): void {
                 eX,
                 eY,
                 button: evt.button,
-                text: a ? a.textContent : null,
+                text: t ? text(t) : null,
                 link: a ? a.href : null,
                 hash: null,
+                selector: null,
             }
         });
         schedule(encode.bind(this, event));
     }
+}
+
+function text(element: Node): string {
+    let output = null;
+    if (element && element.textContent) {
+        // Trim any spaces at the beginning or at the end of string
+        // Also, replace multiple occurrence of space characters with a single white space
+        // Finally, send only first few characters as specified by the Setting
+        output = element.textContent.trim().replace(/\s+/g, Constant.Space).substr(0, Setting.ClickText);
+    }
+    return output;
 }
 
 export function reset(): void {

--- a/packages/clarity-js/src/interaction/click.ts
+++ b/packages/clarity-js/src/interaction/click.ts
@@ -63,8 +63,7 @@ function handler(event: Event, root: Node, evt: MouseEvent): void {
                 button: evt.button,
                 text: t ? text(t) : null,
                 link: a ? a.href : null,
-                hash: null,
-                selector: null,
+                hash: null
             }
         });
         schedule(encode.bind(this, event));

--- a/packages/clarity-js/src/interaction/encode.ts
+++ b/packages/clarity-js/src/interaction/encode.ts
@@ -1,4 +1,5 @@
 import { Event, Token } from "@clarity-types/data";
+import mask from "@src/core/mask";
 import { time } from "@src/core/time";
 import * as baseline from "@src/data/baseline";
 import { queue } from "@src/data/upload";
@@ -50,7 +51,7 @@ export default async function (type: Event): Promise<void> {
                 tokens.push(entry.data.eX);
                 tokens.push(entry.data.eY);
                 tokens.push(entry.data.button);
-                tokens.push(entry.data.text);
+                tokens.push(cTarget.masked ? mask(entry.data.text) : entry.data.text);
                 tokens.push(entry.data.link);
                 tokens.push(cTarget.hash);
                 if (cTarget.region) { tokens.push(cTarget.region); }

--- a/packages/clarity-js/src/interaction/encode.ts
+++ b/packages/clarity-js/src/interaction/encode.ts
@@ -53,6 +53,7 @@ export default async function (type: Event): Promise<void> {
                 tokens.push(entry.data.text);
                 tokens.push(entry.data.link);
                 tokens.push(cTarget.hash);
+                tokens.push(cTarget.selector);
                 if (cTarget.region) { tokens.push(cTarget.region); }
                 queue(tokens);
                 timeline.track(entry.time, entry.event, cTarget.id, entry.data.x, entry.data.y);

--- a/packages/clarity-js/src/interaction/encode.ts
+++ b/packages/clarity-js/src/interaction/encode.ts
@@ -53,7 +53,6 @@ export default async function (type: Event): Promise<void> {
                 tokens.push(entry.data.text);
                 tokens.push(entry.data.link);
                 tokens.push(cTarget.hash);
-                tokens.push(cTarget.selector);
                 if (cTarget.region) { tokens.push(cTarget.region); }
                 queue(tokens);
                 timeline.track(entry.time, entry.event, cTarget.id, entry.data.x, entry.data.y);

--- a/packages/clarity-js/src/layout/dom.ts
+++ b/packages/clarity-js/src/layout/dom.ts
@@ -260,8 +260,10 @@ function position(parent: NodeValue, child: NodeValue): number {
         let idx = parent ? parent.children.indexOf(child.id) : -1;
         while (idx-- > 0) {
             let sibling = values[parent.children[idx]];
-            if (child.data.tag === sibling.data.tag) { child.position = sibling.position + 1; }
-            break;
+            if (child.data.tag === sibling.data.tag) {
+                child.position = sibling.position + 1;
+                break;
+            }
         }
     }
     return child.position;
@@ -408,7 +410,7 @@ function copy(input: NodeValue[]): NodeValue[] {
 function track(id: number, source: Source, changed: boolean = true): void {
     // Keep track of the order in which mutations happened, they may not be sequential
     // Edge case: If an element is added later on, and pre-discovered element is moved as a child.
-    // In that case, we need to reorder the prediscovered element in the update list to keep visualization consistent.
+    // In that case, we need to reorder the pre-discovered element in the update list to keep visualization consistent.
     let uIndex = updateMap.indexOf(id);
     if (uIndex >= 0 && source === Source.ChildListAdd) {
         updateMap.splice(uIndex, 1);

--- a/packages/clarity-js/src/layout/encode.ts
+++ b/packages/clarity-js/src/layout/encode.ts
@@ -71,7 +71,7 @@ export default async function (type: Event, ts: number = null): Promise<void> {
                 }
                 tokens = tokenize(tokens, metadata);
             }
-            if (type == Event.Mutation) { baseline.activity(eventTime); }
+            if (type === Event.Mutation) { baseline.activity(eventTime); }
             queue(tokens, !config.lean);
             break;
     }

--- a/packages/clarity-js/src/layout/selector.ts
+++ b/packages/clarity-js/src/layout/selector.ts
@@ -16,9 +16,7 @@ export default function(tag: string, prefix: string, attributes: Attributes, pos
             if (prefix === null) { return Constant.Empty; }
             tag = tag.indexOf(Constant.SvgPrefix) === 0 ? tag.substr(Constant.SvgPrefix.length) : tag;
             let selector = `${prefix}${tag}${suffix}`;
-            if (Constant.Id in attributes && attributes[Constant.Id].length > 0) {
-                selector = `${tag}#${attributes.id}`;
-            } else if (Constant.Class in attributes && attributes[Constant.Class].length > 0) {
+            if (Constant.Class in attributes && attributes[Constant.Class].length > 0) {
                 selector = `${prefix}${tag}.${attributes.class.trim().split(/\s+/).join(".")}${suffix}`;
             }
             return selector;

--- a/packages/clarity-js/src/layout/target.ts
+++ b/packages/clarity-js/src/layout/target.ts
@@ -24,13 +24,14 @@ export function link(node: Node): HTMLAnchorElement {
 
 export function metadata(node: Node, trackRegion?: boolean): TargetMetadata {
     // If the node is null, we return a reserved value for id: 0. Valid assignment of id begins from 1+.
-    let output: TargetMetadata = { id: 0, region: null, hash: null, node };
+    let output: TargetMetadata = { id: 0, region: null, hash: null, masked: true, node };
     if (node) {
         let value = dom.get(node);
         if (value !== null) {
             output.id = value.id;
             output.region = value.region;
             output.hash = value.selector ? hash(value.selector) : null;
+            output.masked = value.metadata.masked;
             if (trackRegion && value.region) {
                 track(value.region)
             }

--- a/packages/clarity-js/src/layout/target.ts
+++ b/packages/clarity-js/src/layout/target.ts
@@ -24,13 +24,14 @@ export function link(node: Node): HTMLAnchorElement {
 
 export function metadata(node: Node, trackRegion?: boolean): TargetMetadata {
     // If the node is null, we return a reserved value for id: 0. Valid assignment of id begins from 1+.
-    let output: TargetMetadata = { id: 0, region: null, hash: null, node };
+    let output: TargetMetadata = { id: 0, region: null, hash: null, selector: null, node };
     if (node) {
         let value = dom.get(node);
         if (value !== null) {
             output.id = value.id;
             output.region = value.region;
             output.hash = value.selector ? hash(value.selector) : null;
+            output.selector = value.selector;
             if (trackRegion && value.region) {
                 track(value.region)
             }

--- a/packages/clarity-js/src/layout/target.ts
+++ b/packages/clarity-js/src/layout/target.ts
@@ -24,14 +24,13 @@ export function link(node: Node): HTMLAnchorElement {
 
 export function metadata(node: Node, trackRegion?: boolean): TargetMetadata {
     // If the node is null, we return a reserved value for id: 0. Valid assignment of id begins from 1+.
-    let output: TargetMetadata = { id: 0, region: null, hash: null, selector: null, node };
+    let output: TargetMetadata = { id: 0, region: null, hash: null, node };
     if (node) {
         let value = dom.get(node);
         if (value !== null) {
             output.id = value.id;
             output.region = value.region;
             output.hash = value.selector ? hash(value.selector) : null;
-            output.selector = value.selector;
             if (trackRegion && value.region) {
                 track(value.region)
             }

--- a/packages/clarity-js/types/core.d.ts
+++ b/packages/clarity-js/types/core.d.ts
@@ -2,6 +2,7 @@ import { Metadata, Payload, Token } from "./data";
 
 type TaskFunction = () => Promise<void>;
 type TaskResolve = () => void;
+type UploadCallback = (data: string) => void;
 
 /* Enum */
 
@@ -67,8 +68,16 @@ export interface BrowserEvent {
     capture: boolean;
 }
 
+export interface Report {
+    m: string; // Message
+    p: string; // Project Id
+    u: string; // User Id
+    s: string; // Session Id
+    n: number; // Page Number
+}
+
 export interface Config {
-    projectId?: number;
+    projectId?: string;
     delay?: number;
     cssRules?: boolean;
     lean?: boolean;
@@ -78,6 +87,6 @@ export interface Config {
     unmask?: string[];
     regions?: Regions;
     cookies?: string[];
-    url?: string;
-    upload?: (data: string) => void;
+    report?: string;
+    upload?: string | UploadCallback;
 }

--- a/packages/clarity-js/types/data.d.ts
+++ b/packages/clarity-js/types/data.d.ts
@@ -174,7 +174,6 @@ export interface TargetMetadata {
     id: number;
     region: number;
     hash: number;
-    selector: string;
     node: Node;
 }
 

--- a/packages/clarity-js/types/data.d.ts
+++ b/packages/clarity-js/types/data.d.ts
@@ -174,6 +174,7 @@ export interface TargetMetadata {
     id: number;
     region: number;
     hash: number;
+    masked: boolean;
     node: Node;
 }
 

--- a/packages/clarity-js/types/data.d.ts
+++ b/packages/clarity-js/types/data.d.ts
@@ -116,6 +116,7 @@ export const enum Setting {
     PingInterval = 1 * Time.Minute, // 1 Minute
     PingTimeout = 5 * Time.Minute, // 5 Minutes
     SummaryInterval = 100, // Same events within 100ms will be collapsed into single summary
+    ClickText = 25, // Maximum number of characters to send as part of Click event's text field
     PayloadLimit = 128, // Do not allow more than specified payloads per page
     ShutdownLimit = 2 * Time.Hour, // Shutdown instrumentation after specified time
     RetryLimit = 2, // Maximum number of attempts to upload a payload before giving up
@@ -137,9 +138,9 @@ export const enum Constant {
     Equals = "=",
     Path = ";path=/",
     String = "string",
-    UpgradeKey = "_club", // Clarity Upgrade Beta
-    CookieKey = "_clcb", // Clarity Cookie Beta
-    StorageKey = "_clsb", // Clarity Storage Beta
+    UpgradeKey = "_cluc", // Clarity Upgrade Beta
+    CookieKey = "_clcc", // Clarity Cookie Beta
+    StorageKey = "_clsc", // Clarity Storage Beta
     Separator = "|",
     End = "END",
     Upgrade = "UPGRADE",
@@ -163,9 +164,9 @@ export interface EncodedPayload {
 }
 
 export interface Metadata {
-    projectId: number;
-    userId: number;
-    sessionId: number;
+    projectId: string;
+    userId: string;
+    sessionId: string;
     pageNum: number;
 }
 
@@ -173,6 +174,7 @@ export interface TargetMetadata {
     id: number;
     region: number;
     hash: number;
+    selector: string;
     node: Node;
 }
 

--- a/packages/clarity-js/types/interaction.d.ts
+++ b/packages/clarity-js/types/interaction.d.ts
@@ -71,6 +71,7 @@ export interface ClickData {
     text: string;
     link: string;
     hash: number;
+    selector: string;
     region?: number;
 }
 

--- a/packages/clarity-js/types/interaction.d.ts
+++ b/packages/clarity-js/types/interaction.d.ts
@@ -71,7 +71,6 @@ export interface ClickData {
     text: string;
     link: string;
     hash: number;
-    selector: string;
     region?: number;
 }
 

--- a/packages/clarity-visualize/package.json
+++ b/packages/clarity-visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-visualize",
-  "version": "0.6.0-beta.8",
+  "version": "0.6.0-beta.9",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.6.0-beta.8"
+    "clarity-decode": "^0.6.0-beta.9"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.1.0",


### PR DESCRIPTION
- Change ids to be string instead of number
- Add selector field to Click event for debugging
- Capture text for non-link elements too
- Limit click text to 25 characters (configured by Setting)
- Remove backward compatibility for .next field while parsing DOM
- Fixing bug to compute selector correctly during decode logic
- Removing id field from computing selector