### PR TITLE
Reraise Error in insertRule wrapper to fix styled-components

### DIFF
--- a/packages/clarity-js/src/layout/mutation.ts
+++ b/packages/clarity-js/src/layout/mutation.ts
@@ -42,7 +42,7 @@ export function start(): void {
         return value;
       } catch (error) {
         log.log(Code.CssRules, error, Severity.Info);
-        raise error;
+        throw error;
       }
     };
 

--- a/packages/clarity-js/src/layout/mutation.ts
+++ b/packages/clarity-js/src/layout/mutation.ts
@@ -42,6 +42,10 @@ export function start(): void {
         return value;
       } catch (error) {
         log.log(Code.CssRules, error, Severity.Info);
+
+        // The reason we need to throw the error is to stay in line with the `insertRule` specification.
+        // MDN: https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet/insertRule#Restrictions
+        // WC3: https://www.w3.org/TR/DOM-Level-2-Style/css.html - Exceptions listed here. 
         throw error;
       }
     };

--- a/packages/clarity-js/src/layout/mutation.ts
+++ b/packages/clarity-js/src/layout/mutation.ts
@@ -42,7 +42,7 @@ export function start(): void {
         return value;
       } catch (error) {
         log.log(Code.CssRules, error, Severity.Info);
-        return null;
+        raise error;
       }
     };
 


### PR DESCRIPTION
We are running into an issue with styled-components. The current wrapper of insertRule breaks styled components when there is invalid css. Note that invalid css also includes css that is valid in firefox but not chrome.

For example: `.kcpktl::-moz-placeholder{color:#959EA8;}` should raise an error but in the current implementation it does not. This is valid in firefox, but not in chrome.

In styled-components it is expected that insertRule raises an exception when there is an error and does not increment index in that case.  See the following code:
https://github.com/styled-components/styled-components/blob/147b0e9a1f10786551b13fd27452fcd5c678d5e0/packages/styled-components/src/sheet/Tag.js#L35-L43

The solution here is to raise the original error back that the caller can catch on insertRule's error.

Also, this code is currently in production despite being on the 'beta' branch. We've had many customer reports of incorrrect css being applied. I'm not personally familiar with how your customers opt into the beta. This is how customers install clarity's snippet. 

```
    <script type="text/javascript">
    (function(c,l,a,r,i,t,y){
        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
    })(window, document, "clarity", "script", "REDACTED");
</script>
```

The resulting snippet loads `https://www.clarity.ms/scus/s/0.6.0-b21/clarity.js`.

We would appreciate this being merged soon as reasonably possible. We have received several reports from our customers and we can only advise them to uninstall clarity until this is fixed.