### PR TITLE
Using native browser API for MutationObserver

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.6.0",
+  "version": "0.6.1",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clarity",
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "repository": "https://github.com/microsoft/clarity.git",
   "author": "Sarvesh Nagpal <sarveshn@microsoft.com>",
   "license": "MIT",

--- a/packages/clarity-decode/package.json
+++ b/packages/clarity-decode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-decode",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-js": "^0.6.0"
+    "clarity-js": "^0.6.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.1.0",

--- a/packages/clarity-devtools/package.json
+++ b/packages/clarity-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-devtools",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "private": true,
   "description": "Adds Clarity debugging support to browser devtools",
   "author": "Microsoft Corp.",
@@ -24,9 +24,9 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.6.0",
-    "clarity-js": "^0.6.0",
-    "clarity-visualize": "^0.6.0"
+    "clarity-decode": "^0.6.1",
+    "clarity-js": "^0.6.1",
+    "clarity-visualize": "^0.6.1"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^7.1.3",

--- a/packages/clarity-devtools/static/manifest.json
+++ b/packages/clarity-devtools/static/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 2,
   "name": "Clarity Developer Tools",
   "description": "Get insights about how customers use your website.",
-  "version": "0.6.0",
-  "version_name": "0.6.0",
+  "version": "0.6.1",
+  "version_name": "0.6.1",
   "minimum_chrome_version": "50",
   "devtools_page": "devtools.html",
   "icons": {

--- a/packages/clarity-js/package.json
+++ b/packages/clarity-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/packages/clarity-js/src/core/task.ts
+++ b/packages/clarity-js/src/core/task.ts
@@ -73,8 +73,11 @@ function run(): void {
 }
 
 export function shouldYield(method: Metric): boolean {
-    let elapsed = performance.now() - tracker[method].start;
-    return (elapsed > tracker[method].yield);
+    if (method in tracker) {
+        let elapsed = performance.now() - tracker[method].start;
+        return (elapsed > tracker[method].yield);
+    }
+    return true;
 }
 
 export function start(method: Metric): void {

--- a/packages/clarity-js/src/core/version.ts
+++ b/packages/clarity-js/src/core/version.ts
@@ -1,2 +1,2 @@
-let version = "0.6.0";
+let version = "0.6.1";
 export default version;

--- a/packages/clarity-js/types/data.d.ts
+++ b/packages/clarity-js/types/data.d.ts
@@ -92,7 +92,8 @@ export const enum Code {
     RunTask = 0,
     CssRules = 1,
     MutationObserver = 2,
-    PerformanceObserver = 3
+    PerformanceObserver = 3,
+    CallStackDepth = 4
 }
 
 export const enum Severity {
@@ -130,6 +131,7 @@ export const enum Setting {
     ScriptErrorLimit = 5, // Do not send the same script error more than 5 times per page
     WordLength = 5, // Estimated average size of a word,
     RestartDelay = 250, // Wait for 250ms before starting to wire up again
+    CallStackDepth = 20 // Maximum call stack depth before bailing out
 }
 
 export const enum Constant {

--- a/packages/clarity-js/types/layout.d.ts
+++ b/packages/clarity-js/types/layout.d.ts
@@ -51,7 +51,10 @@ export const enum Constant {
     LoadEvent = "load",
     Pixel = "px",
     BorderBox = "border-box",
-    Value = "value"
+    Value = "value",
+    MutationObserver = "MutationObserver",
+    Zone = "Zone",
+    Symbol = "__symbol__"
 }
 
 export const enum JsonLD { 

--- a/packages/clarity-visualize/package.json
+++ b/packages/clarity-visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-visualize",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.6.0"
+    "clarity-decode": "^0.6.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.1.0",


### PR DESCRIPTION
In an edge case it's possible for Angular + Clarity to get stuck into infinite mutation loop. Early investigation suggests it could be due to the way Zone.js overrides MutationObserver API. This fix is to utilize native browser API and therefore prevent side effects. A related issue that has more details: https://github.com/angular/angular/issues/31712