### PR TITLE
Handle case when user clicks an input that has data in it

### DIFF
--- a/packages/clarity-js/src/core/scrub.ts
+++ b/packages/clarity-js/src/core/scrub.ts
@@ -28,6 +28,8 @@ export default function(value: string, hint: string, privacy: Privacy, mangle: b
                     case "alt":
                         return privacy === Privacy.TextImage ? Data.Constant.Empty : value;
                     case "value":
+                    case "click":
+                        // To handle scenario where user clicks an input control that has data in it
                     case "input":
                         return mangleToken(value);
                     case "placeholder":


### PR DESCRIPTION
When a user clicks an existing input box and clicks out of it, even with mask tag set to true, data was being sent as unmasked.