### PR TITLE
Changes to sessionization logic and price extraction

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.6.10",
+  "version": "0.6.11",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clarity",
   "private": true,
-  "version": "0.6.10",
+  "version": "0.6.11",
   "repository": "https://github.com/microsoft/clarity.git",
   "author": "Sarvesh Nagpal <sarveshn@microsoft.com>",
   "license": "MIT",

--- a/packages/clarity-decode/package.json
+++ b/packages/clarity-decode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-decode",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-js": "^0.6.10"
+    "clarity-js": "^0.6.11"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.1.0",

--- a/packages/clarity-devtools/package.json
+++ b/packages/clarity-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-devtools",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "private": true,
   "description": "Adds Clarity debugging support to browser devtools",
   "author": "Microsoft Corp.",
@@ -24,9 +24,9 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.6.10",
-    "clarity-js": "^0.6.10",
-    "clarity-visualize": "^0.6.10"
+    "clarity-decode": "^0.6.11",
+    "clarity-js": "^0.6.11",
+    "clarity-visualize": "^0.6.11"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^7.1.3",

--- a/packages/clarity-devtools/static/manifest.json
+++ b/packages/clarity-devtools/static/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 2,
   "name": "Clarity Developer Tools",
   "description": "Get insights about how customers use your website.",
-  "version": "0.6.10",
-  "version_name": "0.6.10",
+  "version": "0.6.11",
+  "version_name": "0.6.11",
   "minimum_chrome_version": "50",
   "devtools_page": "devtools.html",
   "icons": {

--- a/packages/clarity-js/package.json
+++ b/packages/clarity-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/packages/clarity-js/src/core/config.ts
+++ b/packages/clarity-js/src/core/config.ts
@@ -12,6 +12,7 @@ let config: Config = {
     regions: {},
     metrics: {},
     cookies: [],
+    server: null,
     report: null,
     upload: null,
     upgrade: null

--- a/packages/clarity-js/src/core/version.ts
+++ b/packages/clarity-js/src/core/version.ts
@@ -1,2 +1,2 @@
-let version = "0.6.10";
+let version = "0.6.11";
 export default version;

--- a/packages/clarity-js/src/data/metadata.ts
+++ b/packages/clarity-js/src/data/metadata.ts
@@ -130,8 +130,10 @@ function shortid(): string {
 
 function session(): Session {
   let output: Session = { session: shortid(), ts: Math.round(Date.now()), count: 1, upgrade: BooleanFlag.False, upload: Constant.Empty };
+  // In subsequent versions we will start reading cookies: getCookie(Constant.SessionKey)
+  // For backward compatibility, we will continue reading from session storage in this version
   let legacy = supported(window, Constant.SessionStorage) ? sessionStorage.getItem(Constant.SessionKey) : null; // For backward compatibility
-  let value = getCookie(Constant.SessionKey) || legacy;
+  let value = legacy;
   if (value) {
     let parts = value.split(Constant.Pipe);
     if (parts.length === 5 && output.ts - num(parts[1]) < Setting.SessionTimeout) {

--- a/packages/clarity-js/src/data/metadata.ts
+++ b/packages/clarity-js/src/data/metadata.ts
@@ -138,7 +138,6 @@ function session(): Session {
     let parts = value.split(Constant.Pipe);
     if (parts.length === 5 && output.ts - num(parts[1]) < Setting.SessionTimeout) {
       output.session = parts[0];
-      output.ts = num(parts[1]);
       output.count = num(parts[2]) + 1;
       output.upgrade = num(parts[3]);
       output.upload = parts[4];

--- a/packages/clarity-js/src/data/metadata.ts
+++ b/packages/clarity-js/src/data/metadata.ts
@@ -91,7 +91,7 @@ function tab(): string {
   let id = shortid();
   if (config.track && supported(window, Constant.SessionStorage)) {
     let value = sessionStorage.getItem(Constant.TabKey);
-    id = value && value.indexOf(Constant.Pipe) < 0 ? value : id;
+    id = value ? value : id;
     sessionStorage.setItem(Constant.TabKey, id);
   }
   return id;
@@ -129,8 +129,8 @@ function shortid(): string {
 
 function session(): Session {
   let output: Session = { session: shortid(), ts: Math.round(Date.now()), count: 1, upgrade: BooleanFlag.False, upload: Constant.Empty };
-  let legacy = supported(window, Constant.SessionStorage) ? sessionStorage.getItem(Constant.SessionKey) : null;
-  let value = getCookie(Constant.SessionKey) || legacy;
+  let legacy = supported(window, Constant.SessionStorage) ? sessionStorage.getItem(Constant.SessionKey) : null; // For backward compatibility
+  let value = legacy || getCookie(Constant.SessionKey);
   if (value) {
     let parts = value.split(Constant.Pipe);
     if (parts.length === 5 && output.ts - num(parts[1]) < Setting.SessionTimeout) {

--- a/packages/clarity-js/src/data/metadata.ts
+++ b/packages/clarity-js/src/data/metadata.ts
@@ -107,6 +107,7 @@ export function save(): void {
   // For backward compatibility - starting from v0.6.11. Can be removed in future versions.
   // This will ensure that older versions can still interpret and continue with sessions created with new version
   if (config.track && supported(window, Constant.SessionStorage)) {
+    upload = typeof config.upload === Constant.String && config.server ? `${config.server}/${config.upload}` : upload;
     sessionStorage.setItem(Constant.SessionKey, [data.sessionId, ts, data.pageNum, upgrade, upload].join(Constant.Pipe));
   }
 }
@@ -130,7 +131,7 @@ function shortid(): string {
 function session(): Session {
   let output: Session = { session: shortid(), ts: Math.round(Date.now()), count: 1, upgrade: BooleanFlag.False, upload: Constant.Empty };
   let legacy = supported(window, Constant.SessionStorage) ? sessionStorage.getItem(Constant.SessionKey) : null; // For backward compatibility
-  let value = legacy || getCookie(Constant.SessionKey);
+  let value = getCookie(Constant.SessionKey) || legacy;
   if (value) {
     let parts = value.split(Constant.Pipe);
     if (parts.length === 5 && output.ts - num(parts[1]) < Setting.SessionTimeout) {
@@ -139,6 +140,13 @@ function session(): Session {
       output.count = num(parts[2]) + 1;
       output.upgrade = num(parts[3]);
       output.upload = parts[4];
+
+      // For backward compatibility; remove in future iterations (v0.6.11)
+      if (output.upload && output.upload.indexOf(Constant.HTTPS) === 0) {
+        let url = output.upload;
+        let server = url.substr(0, url.indexOf("/", Constant.HTTPS.length));
+        output.upload = server.length > 0 && server.length < url.length ? url.substr(server.length + 1) : url;
+      }
     }
   }
   return output;

--- a/packages/clarity-js/src/data/metric.ts
+++ b/packages/clarity-js/src/data/metric.ts
@@ -5,9 +5,9 @@ import encode from "./encode";
 export let data: MetricData = null;
 export let updates: MetricData = null;
 let metricMap: WeakMap<Node, string> = null; // Maps metric nodes => innerText
-const numberRegex = /[^0-9\.,]/g;
-const digitsRegex = /[^0-9\.]/g;
 const formatRegex = /1/g;
+const digitsRegex = /[^0-9\.]/g;
+const digitsWithCommaRegex = /[^0-9\.,]/g;
 
 export function start(): void {
     data = {};
@@ -72,7 +72,7 @@ function parseNumber(text: string): number {
     // Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat
     let lang = document.documentElement.lang;
     if (Intl && Intl.NumberFormat && lang) {
-        text = text.replace(numberRegex, Constant.Empty);
+        text = text.replace(digitsWithCommaRegex, Constant.Empty);
         // Infer current group and decimal separator from current locale
         let group = Intl.NumberFormat(lang).format(11111).replace(formatRegex, Constant.Empty);
         let decimal = Intl.NumberFormat(lang).format(1.1).replace(formatRegex, Constant.Empty);

--- a/packages/clarity-js/src/data/metric.ts
+++ b/packages/clarity-js/src/data/metric.ts
@@ -5,7 +5,9 @@ import encode from "./encode";
 export let data: MetricData = null;
 export let updates: MetricData = null;
 let metricMap: WeakMap<Node, string> = null; // Maps metric nodes => innerText
-const regex = /[^0-9\.]/g;
+const numberRegex = /[^0-9\.,]/g;
+const digitsRegex = /[^0-9\.]/g;
+const formatRegex = /1/g;
 
 export function start(): void {
     data = {};
@@ -26,7 +28,7 @@ export function extract(metric: Metric, element: Element): void {
         // Only re-process element if either the element is just discovered or the inner text has changed
         if (metricMap.has(element) === false || metricMap.get(element) !== text) {
             metricMap.set(element, text);
-            let value = Math.round(parseFloat(text.replace(Constant.Comma, Constant.Dot).replace(regex, Constant.Empty)) * 100);
+            let value = parseNumber(text);
             max(metric, value ? value : 0); // Default value to zero in case we are unable to parse text
         }
     } catch { log.log(Code.Metric, null, Severity.Info); };
@@ -64,4 +66,24 @@ export function compute(): void {
 
 export function reset(): void {
     updates = {};
+}
+
+function parseNumber(text: string): number {
+    // Reference: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat
+    let lang = document.documentElement.lang;
+    if (Intl && Intl.NumberFormat && lang) {
+        text = text.replace(numberRegex, Constant.Empty);
+        // Infer current group and decimal separator from current locale
+        let group = Intl.NumberFormat(lang).format(11111).replace(formatRegex, Constant.Empty);
+        let decimal = Intl.NumberFormat(lang).format(1.1).replace(formatRegex, Constant.Empty);
+        
+        // Prase number using inferred group and decimal separators
+        return Math.round(parseFloat(text
+            .replace(new RegExp('\\' + group, 'g'), Constant.Empty)
+            .replace(new RegExp('\\' + decimal), Constant.Dot)
+        ) * 100);
+    }
+
+    // Fallback to en locale
+    return Math.round(parseFloat(text.replace(digitsRegex, Constant.Empty)) * 100);
 }

--- a/packages/clarity-js/src/data/upload.ts
+++ b/packages/clarity-js/src/data/upload.ts
@@ -126,8 +126,8 @@ function stringify(encoded: EncodedPayload): string {
 
 function send(payload: string, sequence: number, last: boolean): void {
     // Upload data if a valid URL is defined in the config
-    if (typeof config.upload === Constant.String) {
-        const url = config.upload as string;
+    if (typeof config.upload === Constant.String && config.server) {
+        const url = `${config.server}/${config.upload}`;
         let dispatched = false;
 
         // If it's the last payload, attempt to upload using sendBeacon first.

--- a/packages/clarity-js/types/core.d.ts
+++ b/packages/clarity-js/types/core.d.ts
@@ -102,6 +102,7 @@ export interface Config {
     regions?: Regions;
     metrics?: Metrics;
     cookies?: string[];
+    server?: string;
     report?: string;
     upload?: string | UploadCallback;
     upgrade?: (key: string) => void;

--- a/packages/clarity-js/types/data.d.ts
+++ b/packages/clarity-js/types/data.d.ts
@@ -183,7 +183,7 @@ export const enum Constant {
     CookieKey = "_clck", // Clarity Cookie Key
     SessionKey = "_clsk", // Clarity Session Key
     TabKey = "_cltk", // Clarity Tab Key
-    Separator = "|",
+    Pipe = "|",
     End = "END",
     Upgrade = "UPGRADE",
     UserId = "userId",

--- a/packages/clarity-js/types/data.d.ts
+++ b/packages/clarity-js/types/data.d.ts
@@ -92,7 +92,9 @@ export const enum Dimension {
     ProductCategory = 11,
     ProductSku = 12,
     ProductCurrency = 13,
-    ProductCondition = 14
+    ProductCondition = 14,
+    TabId = 15,
+    PageLanguage = 16
 }
 
 export const enum Check {
@@ -134,7 +136,8 @@ export const enum BooleanFlag {
 
 export const enum Setting {
     Expire = 365, // 1 Year
-    SessionTimeout = 30 * Time.Minute, // 10 minutes
+    SessionExpire = 1, // 1 Day
+    SessionTimeout = 30 * Time.Minute, // 30 minutes
     PingInterval = 1 * Time.Minute, // 1 Minute
     PingTimeout = 5 * Time.Minute, // 5 Minutes
     SummaryInterval = 100, // Same events within 100ms will be collapsed into single summary
@@ -178,7 +181,8 @@ export const enum Constant {
     Top = "_top",
     String = "string",
     CookieKey = "_clck", // Clarity Cookie Key
-    StorageKey = "_clsk", // Clarity Storage Key
+    SessionKey = "_clsk", // Clarity Session Key
+    TabKey = "_cltk", // Clarity Tab Key
     Separator = "|",
     End = "END",
     Upgrade = "UPGRADE",
@@ -194,7 +198,8 @@ export const enum Constant {
     LongTask = "longtask",
     FID = "first-input",
     CLS = "layout-shift",
-    LCP = "largest-contentful-paint"
+    LCP = "largest-contentful-paint",
+    HTTPS = "https://"
 }
 
 /* Helper Interfaces */
@@ -219,7 +224,7 @@ export interface Metadata {
 }
 
 export interface Session {
-    id: string;
+    session: string;
     ts: number;
     count: number;
     upgrade: BooleanFlag;

--- a/packages/clarity-visualize/package.json
+++ b/packages/clarity-visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-visualize",
-  "version": "0.6.10",
+  "version": "0.6.11",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.6.10"
+    "clarity-decode": "^0.6.11"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.1.0",


### PR DESCRIPTION
- Moving to session cookie instead of session storage since it's unreliable on iOS Safari
- Bumping up the version to 0.6.11
- Adding support for TabId as part of a dimension (still through Session Storage)
- Updating cookie handling to be forward compatible for future changes