### PR TITLE
JSON+LD fixes and moving sessionization to use cookies

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.6.11",
+  "version": "0.6.12",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clarity",
   "private": true,
-  "version": "0.6.11",
+  "version": "0.6.12",
   "repository": "https://github.com/microsoft/clarity.git",
   "author": "Sarvesh Nagpal <sarveshn@microsoft.com>",
   "license": "MIT",

--- a/packages/clarity-decode/package.json
+++ b/packages/clarity-decode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-decode",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-js": "^0.6.11"
+    "clarity-js": "^0.6.12"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.1.0",

--- a/packages/clarity-devtools/package.json
+++ b/packages/clarity-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-devtools",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "private": true,
   "description": "Adds Clarity debugging support to browser devtools",
   "author": "Microsoft Corp.",
@@ -24,9 +24,9 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.6.11",
-    "clarity-js": "^0.6.11",
-    "clarity-visualize": "^0.6.11"
+    "clarity-decode": "^0.6.12",
+    "clarity-js": "^0.6.12",
+    "clarity-visualize": "^0.6.12"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^7.1.3",

--- a/packages/clarity-devtools/static/manifest.json
+++ b/packages/clarity-devtools/static/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 2,
   "name": "Clarity Developer Tools",
   "description": "Get insights about how customers use your website.",
-  "version": "0.6.11",
-  "version_name": "0.6.11",
+  "version": "0.6.12",
+  "version_name": "0.6.12",
   "minimum_chrome_version": "50",
   "devtools_page": "devtools.html",
   "icons": {

--- a/packages/clarity-js/package.json
+++ b/packages/clarity-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/packages/clarity-js/src/core/version.ts
+++ b/packages/clarity-js/src/core/version.ts
@@ -1,2 +1,2 @@
-let version = "0.6.11";
+let version = "0.6.12";
 export default version;

--- a/packages/clarity-js/src/data/metric.ts
+++ b/packages/clarity-js/src/data/metric.ts
@@ -51,7 +51,8 @@ export function sum(metric: Metric, value: number): void {
 }
 
 export function max(metric: Metric, value: number): void {
-    if (value !== null) { 
+    // Ensure that we do not process null or NaN values
+    if (value !== null && isNaN(value) === false) { 
         if (!(metric in data)) { data[metric] = 0; }
         if (value > data[metric] || data[metric] === 0) {
             updates[metric] = value;

--- a/packages/clarity-js/src/data/upload.ts
+++ b/packages/clarity-js/src/data/upload.ts
@@ -124,7 +124,7 @@ function stringify(encoded: EncodedPayload): string {
     return encoded.p.length > 0 ? `{"e":${encoded.e},"a":${encoded.a},"p":${encoded.p}}` : `{"e":${encoded.e},"a":${encoded.a}}`;
 }
 
-function send(payload: string, sequence: number, last: boolean): void {
+function send(payload: string, sequence: number, beacon: boolean): void {
     // Upload data if a valid URL is defined in the config
     if (typeof config.upload === Constant.String && config.server) {
         const url = `${config.server}/${config.upload}`;
@@ -133,7 +133,7 @@ function send(payload: string, sequence: number, last: boolean): void {
         // If it's the last payload, attempt to upload using sendBeacon first.
         // The advantage to using sendBeacon is that browser can decide to upload asynchronously, improving chances of success
         // However, we don't want to rely on it for every payload, since we have no ability to retry if the upload failed.
-        if (last && "sendBeacon" in navigator) {
+        if (beacon && "sendBeacon" in navigator) {
             dispatched = navigator.sendBeacon(url, payload);
         }
 
@@ -146,7 +146,7 @@ function send(payload: string, sequence: number, last: boolean): void {
             if (sequence in transit) { transit[sequence].attempts++; } else { transit[sequence] = { data: payload, attempts: 1 }; }
             let xhr = new XMLHttpRequest();
             xhr.open("POST", url);
-            if (sequence !== null) { xhr.onreadystatechange = (): void => { measure(check)(xhr, sequence, last); }; }
+            if (sequence !== null) { xhr.onreadystatechange = (): void => { measure(check)(xhr, sequence, beacon); }; }
             xhr.withCredentials = true;
             xhr.send(payload);
         }
@@ -161,19 +161,26 @@ function check(xhr: XMLHttpRequest, sequence: number, last: boolean): void {
     if (xhr && xhr.readyState === XMLHttpRequest.DONE && transitData) {
         // Attempt send payload again (as configured in settings) if we do not receive a success (2XX) response code back from the server
         if ((xhr.status < 200 || xhr.status > 208) && transitData.attempts <= Setting.RetryLimit) {
-            // The only exception is if we receive 400 error code,
-            // which indicates the server has rejected the response for bad payload and we should terminate the session.
-            if (xhr.status === 400) {
-                limit.trigger(Check.Server);
-            } else { send(transitData.data, sequence, last); }
+            // We re-attempt in all cases except two: 
+            //     0: Indicates the browser has not put the request on the wire and therefore we need to attempt sendBeacon API before giving up
+            //   400: Indicates the server has rejected the response for bad payload and therefore we terminate the session
+            switch (xhr.status) {
+                // The observed behavior is that Safari will terminate pending XHR requests with status code 0
+                // if the user navigates away from the page. In these cases, we fallback to the else clause and lose the data
+                // By explicitly handing status code 0 we attempt to try a different transport (sendBeacon vs. XHR) before giving up.
+                case 0: send(transitData.data, sequence, true); break;
+                case 400: limit.trigger(Check.Server); break;
+                default: send(transitData.data, sequence, last); break;
+            }
         } else {
             track = { sequence, attempts: transitData.attempts, status: xhr.status };
             // Send back an event only if we were not successful in our first attempt
             if (transitData.attempts > 1) { encode(Event.Upload); }
             // Handle response if it was a 200 response with a valid body
             if (xhr.status === 200 && xhr.responseText) { response(xhr.responseText); }
-            // If we exhausted our retries the trigger Clarity shutdown for this page
-            if (transitData.attempts > Setting.RetryLimit) { limit.trigger(Check.Retry); }
+            // If we exhausted our retries then trigger Clarity shutdown for this page.
+            // The only exception is if browser decided to not even put the request on the network (status code: 0)
+            if (transitData.attempts > Setting.RetryLimit && xhr.status !== 0) { limit.trigger(Check.Retry); }
             // Stop tracking this payload now that it's all done
             delete transit[sequence];
         }

--- a/packages/clarity-js/src/layout/schema.ts
+++ b/packages/clarity-js/src/layout/schema.ts
@@ -3,6 +3,8 @@ import { Constant, JsonLD } from "@clarity-types/layout";
 import * as dimension from "@src/data/dimension";
 import * as metric from "@src/data/metric";
 
+const digitsRegex = /[^0-9\.]/g;
+
 /* JSON+LD (Linked Data) Recursive Parser */
 export function ld(json: any): void {
     for (let key of Object.keys(json)) {
@@ -24,7 +26,7 @@ export function ld(json: any): void {
                     break;
                 case JsonLD.AggregateRating:
                     if (json[JsonLD.RatingValue]) {
-                        metric.max(Metric.RatingValue, parseFloat(json[JsonLD.RatingValue]) * Setting.RatingScale);
+                        metric.max(Metric.RatingValue, num(json[JsonLD.RatingValue], Setting.RatingScale));
                         metric.max(Metric.BestRating, num(json[JsonLD.BestRating]));
                         metric.max(Metric.WorstRating, num(json[JsonLD.WorstRating]));
                     }
@@ -39,7 +41,7 @@ export function ld(json: any): void {
                     dimension.log(Dimension.ProductCondition, json[JsonLD.ItemCondition]);
                     dimension.log(Dimension.ProductCurrency, json[JsonLD.PriceCurrency]);
                     dimension.log(Dimension.ProductSku, json[JsonLD.Sku]);
-                    metric.max(Metric.ProductPrice, num(json[JsonLD.Price]));
+                    metric.max(Metric.ProductPrice, num(json[JsonLD.Price], Setting.PriceScale));
                     break;
                 case JsonLD.Brand:
                     dimension.log(Dimension.ProductBrand, json[JsonLD.Name]);
@@ -51,6 +53,12 @@ export function ld(json: any): void {
     }
 }
 
-function num(input: string): number {
-    return input ? Math.round(parseFloat(input)) : null;
+function num(input: string | number, scale: number = 1): number {
+    if (input !== null) {
+        switch (typeof input) {
+            case Constant.Number: return Math.round((input as number) * scale);
+            case Constant.String: return Math.round(parseFloat((input as string).replace(digitsRegex, Constant.Empty)) * scale);
+        }
+    }
+    return null;
 }

--- a/packages/clarity-js/src/layout/schema.ts
+++ b/packages/clarity-js/src/layout/schema.ts
@@ -41,7 +41,7 @@ export function ld(json: any): void {
                     dimension.log(Dimension.ProductCondition, json[JsonLD.ItemCondition]);
                     dimension.log(Dimension.ProductCurrency, json[JsonLD.PriceCurrency]);
                     dimension.log(Dimension.ProductSku, json[JsonLD.Sku]);
-                    metric.max(Metric.ProductPrice, num(json[JsonLD.Price], Setting.PriceScale));
+                    metric.max(Metric.ProductPrice, num(json[JsonLD.Price]));
                     break;
                 case JsonLD.Brand:
                     dimension.log(Dimension.ProductBrand, json[JsonLD.Name]);

--- a/packages/clarity-js/types/data.d.ts
+++ b/packages/clarity-js/types/data.d.ts
@@ -155,7 +155,6 @@ export const enum Setting {
     RestartDelay = 250, // Wait for 250ms before starting to wire up again
     CallStackDepth = 20, // Maximum call stack depth before bailing out
     RatingScale = 100, // Scale rating to specified scale
-    PriceScale = 100, // Scale price to specified scale
     ViewportIntersectionRatio = 0.25, // Ratio of intersection area in comparison to viewport area before it's marked visible
     IntersectionRatio = 0.8, // Ratio of intersection area in comparison to element's area before it's marked visible
 }

--- a/packages/clarity-js/types/data.d.ts
+++ b/packages/clarity-js/types/data.d.ts
@@ -155,6 +155,7 @@ export const enum Setting {
     RestartDelay = 250, // Wait for 250ms before starting to wire up again
     CallStackDepth = 20, // Maximum call stack depth before bailing out
     RatingScale = 100, // Scale rating to specified scale
+    PriceScale = 100, // Scale price to specified scale
     ViewportIntersectionRatio = 0.25, // Ratio of intersection area in comparison to viewport area before it's marked visible
     IntersectionRatio = 0.8, // Ratio of intersection area in comparison to element's area before it's marked visible
 }

--- a/packages/clarity-js/types/layout.d.ts
+++ b/packages/clarity-js/types/layout.d.ts
@@ -56,7 +56,9 @@ export const enum Constant {
     MutationObserver = "MutationObserver",
     Zone = "Zone",
     Symbol = "__symbol__",
-    JsonLD = "application/ld+json"
+    JsonLD = "application/ld+json",
+    String = "string",
+    Number = "number"
 }
 
 export const enum JsonLD { 

--- a/packages/clarity-visualize/package.json
+++ b/packages/clarity-visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-visualize",
-  "version": "0.6.11",
+  "version": "0.6.12",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.6.11"
+    "clarity-decode": "^0.6.12"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^11.1.0",

--- a/packages/clarity-visualize/src/data.ts
+++ b/packages/clarity-visualize/src/data.ts
@@ -15,6 +15,7 @@ METRIC_MAP[Data.Metric.LargestPaint] = { name: "LCP", unit: "s" };
 METRIC_MAP[Data.Metric.CumulativeLayoutShift] = { name: "CLS", unit: "cls" };
 METRIC_MAP[Data.Metric.LongTaskCount] = { name: "Long Tasks" };
 METRIC_MAP[Data.Metric.CartTotal] = { name: "Cart Total", unit: "price" };
+METRIC_MAP[Data.Metric.ProductPrice] = { name: "Product Price", unit: "price" };
 METRIC_MAP[Data.Metric.ThreadBlockedTime] = { name: "Thread Blocked", unit: "ms" };
 
 export function reset(): void {

--- a/packages/clarity-visualize/src/data.ts
+++ b/packages/clarity-visualize/src/data.ts
@@ -14,8 +14,8 @@ METRIC_MAP[Data.Metric.LayoutCost] = { name: "Layout Cost", unit: "ms" };
 METRIC_MAP[Data.Metric.LargestPaint] = { name: "LCP", unit: "s" };
 METRIC_MAP[Data.Metric.CumulativeLayoutShift] = { name: "CLS", unit: "cls" };
 METRIC_MAP[Data.Metric.LongTaskCount] = { name: "Long Tasks" };
-METRIC_MAP[Data.Metric.CartTotal] = { name: "Cart Total", unit: "price" };
-METRIC_MAP[Data.Metric.ProductPrice] = { name: "Product Price", unit: "price" };
+METRIC_MAP[Data.Metric.CartTotal] = { name: "Cart Total", unit: "html-price" };
+METRIC_MAP[Data.Metric.ProductPrice] = { name: "Product Price", unit: "ld-price" };
 METRIC_MAP[Data.Metric.ThreadBlockedTime] = { name: "Thread Blocked", unit: "ms" };
 
 export function reset(): void {
@@ -35,7 +35,7 @@ export function metric(event: Data.MetricEvent): void {
         if (typeof event.data[m] === "number") {
             if (!(m in metrics)) { metrics[m] = 0; }
             let key = parseInt(m, 10);
-            if (m in METRIC_MAP && METRIC_MAP[m].unit === "price") { 
+            if (m in METRIC_MAP && (METRIC_MAP[m].unit === "html-price" || METRIC_MAP[m].unit === "ld-price")) { 
                 metrics[m] = event.data[m];
             } else { metrics[m] += event.data[m]; }
             lean = key === Data.Metric.Playback && event.data[m] === 0 ? true : lean;
@@ -80,7 +80,8 @@ export function update(regionId: number): void {
 
 function key(unit: string): string {
     switch (unit) {
-        case "price": 
+        case "html-price": 
+        case "ld-price": 
         case "cls":
             return Data.Constant.Empty;
         default: return unit;
@@ -92,7 +93,7 @@ function value(num: number, unit: string): number {
         case "KB": return Math.round(num / 1024);
         case "s": return Math.round(num / 10) / 100;
         case "cls": return num / 1000;
-        case "price": return num / 100;
+        case "html-price": return num / 100;
         default: return num;
     }
 }


### PR DESCRIPTION
- Better handle unexpected payloads in JSON+LD
- Use cookie instead of session storage for session - so we can track cross tabs
- Fall back to sendBeacon when XHR return status code = 0 (on page getting unloaded). Impacts Safari. 