### PR TITLE
Fix Clarity Interface Typing Error

### DIFF
--- a/packages/clarity-js/types/index.d.ts
+++ b/packages/clarity-js/types/index.d.ts
@@ -7,7 +7,7 @@ import * as Performance from "./performance";
 
 interface Clarity {
   start: (config?: Core.Config) => void;
-  end: () => void;
+  stop: () => void;
   pause: () => void;
   resume: () => void;
   upgrade: (key: string) => void;


### PR DESCRIPTION
I noticed a typing error (typescript) when using clarity.

It seems that this stop function

https://github.com/microsoft/clarity/blob/65aa9401def813f83f82bae3c4d853b667b85405/packages/clarity-js/src/clarity.ts#L47

is being declared as clarity.end in the typescript typing definition. This error came when using the clarity module for ourselves from npm inside of our typescript project.