### PR TITLE
Prevent running multiple instances of Clarity simultaneously

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.6.18",
+  "version": "0.6.19",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clarity",
   "private": true,
-  "version": "0.6.18",
+  "version": "0.6.19",
   "repository": "https://github.com/microsoft/clarity.git",
   "author": "Sarvesh Nagpal <sarveshn@microsoft.com>",
   "license": "MIT",

--- a/packages/clarity-decode/package.json
+++ b/packages/clarity-decode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-decode",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-js": "^0.6.18"
+    "clarity-js": "^0.6.19"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^19.0.1",

--- a/packages/clarity-devtools/package.json
+++ b/packages/clarity-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-devtools",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "private": true,
   "description": "Adds Clarity debugging support to browser devtools",
   "author": "Microsoft Corp.",
@@ -24,9 +24,9 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.6.18",
-    "clarity-js": "^0.6.18",
-    "clarity-visualize": "^0.6.18"
+    "clarity-decode": "^0.6.19",
+    "clarity-js": "^0.6.19",
+    "clarity-visualize": "^0.6.19"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.0.2",

--- a/packages/clarity-devtools/static/manifest.json
+++ b/packages/clarity-devtools/static/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 2,
   "name": "Clarity Developer Tools",
   "description": "Get insights about how customers use your website.",
-  "version": "0.6.18",
-  "version_name": "0.6.18",
+  "version": "0.6.19",
+  "version_name": "0.6.19",
   "minimum_chrome_version": "50",
   "devtools_page": "devtools.html",
   "icons": {

--- a/packages/clarity-js/package.json
+++ b/packages/clarity-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/packages/clarity-js/src/core/version.ts
+++ b/packages/clarity-js/src/core/version.ts
@@ -1,2 +1,2 @@
-let version = "0.6.18";
+let version = "0.6.19";
 export default version;

--- a/packages/clarity-js/src/global.ts
+++ b/packages/clarity-js/src/global.ts
@@ -3,12 +3,20 @@ import * as clarity from "@src/clarity";
 // Expose clarity in a browser environment
 // To be efficient about queuing up operations while Clarity is wiring up, we expose clarity.*(args) => clarity(*, args);
 // This allows us to reprocess any calls that we missed once Clarity is available on the page
+// Once Clarity script bundle is loaded on the page, we also initialize a "v" property that holds current version
+// We use the presence or absence of "v" to determine if we are attempting to run a duplicate instance
 (function(): void {
     if (typeof window !== "undefined") {
         const w = window as any;
-        if (w.clarity && !w.clarity.q) { console.warn("Error CL001: Multiple Clarity tags detected."); }
-        const queue = w.clarity ? (w.clarity.q || []) : [];
-        w.clarity = function(method: string, ...args: any[]): void { return clarity[method](...args); }
-        while (queue.length > 0) { w.clarity(...queue.shift()); }
+        const c = 'clarity';
+        
+        // Do not execute or reset global "clarity" variable if a version of Clarity is already running on the page
+        if (w[c] && w[c].v) { return console.warn("Error CL001: Multiple Clarity tags detected."); }
+        
+        // Re-wire global "clarity" variable to map it to current instance of Clarity
+        const queue = w[c] ? (w[c].q || []) : [];
+        w[c] = function(method: string, ...args: any[]): void { return clarity[method](...args); }
+        w[c].v = clarity.version;
+        while (queue.length > 0) { w[c](...queue.shift()); }
     }
 })();

--- a/packages/clarity-visualize/package.json
+++ b/packages/clarity-visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-visualize",
-  "version": "0.6.18",
+  "version": "0.6.19",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.6.18"
+    "clarity-decode": "^0.6.19"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^19.0.1",


### PR DESCRIPTION
Set a "v" property on the global clarity variable so we can look for it before running a second instance.