### PR TITLE
Persisting server location as part of session information

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.6.19",
+  "version": "0.6.20",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clarity",
   "private": true,
-  "version": "0.6.19",
+  "version": "0.6.20",
   "repository": "https://github.com/microsoft/clarity.git",
   "author": "Sarvesh Nagpal <sarveshn@microsoft.com>",
   "license": "MIT",

--- a/packages/clarity-decode/package.json
+++ b/packages/clarity-decode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-decode",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-js": "^0.6.19"
+    "clarity-js": "^0.6.20"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^19.0.1",

--- a/packages/clarity-devtools/package.json
+++ b/packages/clarity-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-devtools",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "private": true,
   "description": "Adds Clarity debugging support to browser devtools",
   "author": "Microsoft Corp.",
@@ -24,9 +24,9 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.6.19",
-    "clarity-js": "^0.6.19",
-    "clarity-visualize": "^0.6.19"
+    "clarity-decode": "^0.6.20",
+    "clarity-js": "^0.6.20",
+    "clarity-visualize": "^0.6.20"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.0.2",

--- a/packages/clarity-devtools/static/manifest.json
+++ b/packages/clarity-devtools/static/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 2,
   "name": "Clarity Developer Tools",
   "description": "Get insights about how customers use your website.",
-  "version": "0.6.19",
-  "version_name": "0.6.19",
+  "version": "0.6.20",
+  "version_name": "0.6.20",
   "minimum_chrome_version": "50",
   "devtools_page": "devtools.html",
   "icons": {

--- a/packages/clarity-js/package.json
+++ b/packages/clarity-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/packages/clarity-js/src/core/version.ts
+++ b/packages/clarity-js/src/core/version.ts
@@ -1,2 +1,2 @@
-let version = "0.6.19";
+let version = "0.6.20";
 export default version;

--- a/packages/clarity-js/src/data/metadata.ts
+++ b/packages/clarity-js/src/data/metadata.ts
@@ -25,18 +25,10 @@ export function start(): void {
     pageNum: s.count
   }
 
-  // For backward compatibility; remove in future iterations (v0.6.11)
-  if (config.upload && typeof config.upload === Constant.String && (config.upload as string).indexOf(Constant.HTTPS) === 0) {
-    let url = config.upload as string;
-    // Until 0.6.10, upload was expected to be complete URL. With 0.6.11, we send separate "server" config with hostname and path within "upload"
-    // The code below checks if the "upload" value is complete URL, and if so, break it into "server" and "upload".
-    config.server = url.substr(0, url.indexOf("/", Constant.HTTPS.length)); // Look for first "/" starting after initial "https://" string
-    config.upload = config.server.length > 0 && config.server.length < url.length ? url.substr(config.server.length + 1) : url; // Grab path of the url and update "upload" configuration
-  }
-
   // Override configuration based on what's in the session storage
   config.lean = config.track && s.upgrade !== null ? s.upgrade === BooleanFlag.False : config.lean;
   config.upload = config.track && typeof config.upload === Constant.String && s.upload ? s.upload : config.upload;
+  config.server = config.track && s.server ? s.server : config.server;
 
 
   // Log dimensions
@@ -111,7 +103,7 @@ export function save(): void {
   let upgrade = config.lean ? BooleanFlag.False : BooleanFlag.True;
   let upload = typeof config.upload === Constant.String ? config.upload : Constant.Empty;
   if (upgrade && callback) { callback(data, !config.lean); }
-  setCookie(Constant.SessionKey, [data.sessionId, ts, data.pageNum, upgrade, upload].join(Constant.Pipe), Setting.SessionExpire);
+  setCookie(Constant.SessionKey, [data.sessionId, ts, data.pageNum, upgrade, upload, config.server].join(Constant.Pipe), Setting.SessionExpire);
 }
 
 function supported(target: Window | Document, api: string): boolean {
@@ -131,15 +123,17 @@ function shortid(): string {
 }
 
 function session(): Session {
-  let output: Session = { session: shortid(), ts: Math.round(Date.now()), count: 1, upgrade: null, upload: Constant.Empty };
+  let output: Session = { session: shortid(), ts: Math.round(Date.now()), count: 1, upgrade: null, upload: Constant.Empty, server: Constant.Empty };
   let value = getCookie(Constant.SessionKey);
   if (value) {
     let parts = value.split(Constant.Pipe);
-    if (parts.length === 5 && output.ts - num(parts[1]) < Setting.SessionTimeout) {
+    // Making it backward & forward compatible by using greater than comparison
+    if (parts.length >= 5 && output.ts - num(parts[1]) < Setting.SessionTimeout) {
       output.session = parts[0];
       output.count = num(parts[2]) + 1;
       output.upgrade = num(parts[3]);
       output.upload = parts[4];
+      output.server = parts.length >= 6 ? parts[5] : Constant.Empty;
     }
   }
   return output;

--- a/packages/clarity-js/types/data.d.ts
+++ b/packages/clarity-js/types/data.d.ts
@@ -248,6 +248,7 @@ export interface Session {
     count: number;
     upgrade: BooleanFlag;
     upload: string;
+    server: string;
 }
 
 export interface Envelope extends Metadata {

--- a/packages/clarity-visualize/package.json
+++ b/packages/clarity-visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-visualize",
-  "version": "0.6.19",
+  "version": "0.6.20",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.6.19"
+    "clarity-decode": "^0.6.20"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^19.0.1",


### PR DESCRIPTION
- Extension session cookie to store server information and make it forward and backward compatible for future.
- Remove backward compatibility code from 0.6.11 that is no longer needed