### PR TITLE
bug fix: heatmap issues, custom variables

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.6.22",
+  "version": "0.6.23",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/clarity-decode/package.json
+++ b/packages/clarity-decode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-decode",
-  "version": "0.6.22",
+  "version": "0.6.23",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-js": "^0.6.22"
+    "clarity-js": "^0.6.23"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^19.0.1",

--- a/packages/clarity-devtools/package.json
+++ b/packages/clarity-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-devtools",
-  "version": "0.6.22",
+  "version": "0.6.23",
   "private": true,
   "description": "Adds Clarity debugging support to browser devtools",
   "author": "Microsoft Corp.",
@@ -24,9 +24,9 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.6.22",
-    "clarity-js": "^0.6.22",
-    "clarity-visualize": "^0.6.22"
+    "clarity-decode": "^0.6.23",
+    "clarity-js": "^0.6.23",
+    "clarity-visualize": "^0.6.23"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.0.2",

--- a/packages/clarity-js/package.json
+++ b/packages/clarity-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.6.22",
+  "version": "0.6.23",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/packages/clarity-js/src/core/version.ts
+++ b/packages/clarity-js/src/core/version.ts
@@ -1,2 +1,2 @@
-let version = "0.6.22";
+let version = "0.6.23";
 export default version;

--- a/packages/clarity-js/src/data/variable.ts
+++ b/packages/clarity-js/src/data/variable.ts
@@ -25,7 +25,7 @@ function log(variable: string, value: string[]): void {
         value &&
         typeof variable === Constant.String &&
         variable.length < 255) {
-        let validValues = []
+        let validValues = variable in data ? data[variable] : [];
         for (let i = 0; i < value.length; i++) {
             if (typeof value[i] === Constant.String && value[i].length < 255) { validValues.push(value[i]); }
         }

--- a/packages/clarity-js/src/layout/node.ts
+++ b/packages/clarity-js/src/layout/node.ts
@@ -1,7 +1,8 @@
 import { Constant, Source } from "@clarity-types/layout";
-import { Code, Severity } from "@clarity-types/data";
+import { Code, Dimension, Severity } from "@clarity-types/data";
 import config from "@src/core/config";
 import * as dom from "./dom";
+import * as dimension from "@src/data/dimension";
 import * as internal from "@src/diagnostic/internal";
 import * as interaction from "@src/interaction";
 import * as mutation from "@src/layout/mutation";
@@ -104,6 +105,20 @@ export default function (node: Node, source: Source): Node {
                     break;
                 case "NOSCRIPT":
                 case "META":
+                    if (Constant.Property in attributes && Constant.Content in attributes) {
+                        var content = attributes[Constant.Content]
+                        switch(attributes[Constant.Property]) {
+                            case Constant.ogTitle:
+                                dimension.log(Dimension.MetaTitle, content)
+                                break;
+                            case Constant.ogType:
+                                dimension.log(Dimension.MetaType, content)
+                                break;
+                            case Constant.Generator:
+                                dimension.log(Dimension.Generator, content)
+                                break;
+                        } 
+                    }
                     break;
                 case "HEAD":
                     let head = { tag, attributes };

--- a/packages/clarity-js/src/layout/node.ts
+++ b/packages/clarity-js/src/layout/node.ts
@@ -104,9 +104,10 @@ export default function (node: Node, source: Source): Node {
                     }
                     break;
                 case "NOSCRIPT":
+                    break;
                 case "META":
                     if (Constant.Property in attributes && Constant.Content in attributes) {
-                        var content = attributes[Constant.Content]
+                        let content = attributes[Constant.Content]
                         switch(attributes[Constant.Property]) {
                             case Constant.ogTitle:
                                 dimension.log(Dimension.MetaTitle, content)

--- a/packages/clarity-js/src/layout/schema.ts
+++ b/packages/clarity-js/src/layout/schema.ts
@@ -17,6 +17,8 @@ export function ld(json: any): void {
                 case JsonLD.Article:
                 case JsonLD.Recipe:
                     dimension.log(Dimension.SchemaType, json[key]);
+                    dimension.log(Dimension.AuthorName,  json[JsonLD.Creator]);
+                    dimension.log(Dimension.Headline,  json[JsonLD.Headline]);
                     break;
                 case JsonLD.Product:
                     dimension.log(Dimension.SchemaType, json[key]);

--- a/packages/clarity-js/types/data.d.ts
+++ b/packages/clarity-js/types/data.d.ts
@@ -96,7 +96,11 @@ export const enum Dimension {
     TabId = 15,
     PageLanguage = 16,
     DocumentDirection = 17,
-    Headline = 18
+    Headline = 18,
+    MetaType = 19,
+    MetaTitle = 20,
+    Generator = 21
+    
 }
 
 export const enum Check {

--- a/packages/clarity-js/types/data.d.ts
+++ b/packages/clarity-js/types/data.d.ts
@@ -95,7 +95,8 @@ export const enum Dimension {
     ProductCondition = 14,
     TabId = 15,
     PageLanguage = 16,
-    DocumentDirection = 17
+    DocumentDirection = 17,
+    Headline = 18
 }
 
 export const enum Check {

--- a/packages/clarity-js/types/layout.d.ts
+++ b/packages/clarity-js/types/layout.d.ts
@@ -70,7 +70,12 @@ export const enum Constant {
     String = "string",
     Number = "number",
     Disable = "disable",
-    HTML = "HTML"
+    HTML = "HTML",
+    Property = "property",
+    Content = "content",
+    Generator = "generator",
+    ogType = "og:type",
+    ogTitle = "og:title"
 }
 
 export const enum JsonLD { 

--- a/packages/clarity-js/types/layout.d.ts
+++ b/packages/clarity-js/types/layout.d.ts
@@ -94,7 +94,9 @@ export const enum JsonLD {
     Sku = "sku",
     Name = "name",
     Article = "article",
-    Posting = "posting"
+    Posting = "posting",
+    Headline = "headline",
+    Creator = "creator"
 }
 
 export const enum Setting {

--- a/packages/clarity-visualize/package.json
+++ b/packages/clarity-visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-visualize",
-  "version": "0.6.22",
+  "version": "0.6.23",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.6.22"
+    "clarity-decode": "^0.6.23"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^19.0.1",

--- a/packages/clarity-visualize/src/heatmap.ts
+++ b/packages/clarity-visualize/src/heatmap.ts
@@ -54,15 +54,22 @@ export function scroll(activity: ScrollMapInfo[], avgFold: number): void {
     scrollData = scrollData || activity;
     let canvas = overlay();
     let context = canvas.getContext(Constant.Context);
-
+    let doc = state.window.document;
+    var body = doc.body;
+    var de = doc.documentElement;
+    var height = Math.max( body.scrollHeight, body.offsetHeight, 
+        de.clientHeight, de.scrollHeight, de.offsetHeight );
+    canvas.height = Math.min(height, Setting.CanvasMaxHeight);
     if (canvas.width > 0 && canvas.height > 0) {
         if (scrollData) {
             const grd = context.createLinearGradient(0, 0, 0, canvas.height);
             for (const currentCombination of scrollData) {
                 const huePercentView = 1 - (currentCombination.cumulativeSum / scrollData[0].cumulativeSum);
-                const percentView = currentCombination.scrollReachY / 100;
+                const percentView = (currentCombination.scrollReachY / 100) * (height / canvas.height);
                 const hue = huePercentView * Setting.MaxHue;
-                grd.addColorStop(percentView, `hsla(${hue}, 100%, 50%, 0.6)`);
+                if (percentView < 1) {
+                    grd.addColorStop(percentView, `hsla(${hue}, 100%, 50%, 0.6)`);
+                }
             }
 
             // Fill with gradient
@@ -251,15 +258,21 @@ function transform(): Heatmap[] {
 }
 
 function visible(el: HTMLElement, r: DOMRect, height: number): boolean {
-    let doc = state.window.document;
+    let doc: Document | ShadowRoot = state.window.document;
     let visibility = r.height > height ? true : false;
     if (visibility === false && r.width > 0 && r.height > 0) {
-        let elements = doc.elementsFromPoint(r.left + (r.width / 2), r.top + (r.height / 2));
-        for (let e of elements) {
-            // Ignore if top element ends up being the canvas element we added for heatmap visualization
-            if (e.tagName === Constant.Canvas || (e.id && e.id.indexOf(Constant.ClarityPrefix) === 0)) { continue; }
-            visibility = e === el;
-            break;
+        while (!visibility && doc)
+        {
+            let shadowElement = null;
+            let elements = doc.elementsFromPoint(r.left + (r.width / 2), r.top + (r.height / 2));
+            for (let e of elements) {
+                // Ignore if top element ends up being the canvas element we added for heatmap visualization
+                if (e.tagName === Constant.Canvas || (e.id && e.id.indexOf(Constant.ClarityPrefix) === 0)) { continue; }
+                visibility = e === el;
+                shadowElement = e.shadowRoot && e.shadowRoot != doc ? e.shadowRoot : null;
+                break;
+            }
+            doc = shadowElement;
         }
     }
     return visibility && r.bottom >= 0 && r.top <= height;

--- a/packages/clarity-visualize/src/heatmap.ts
+++ b/packages/clarity-visualize/src/heatmap.ts
@@ -59,7 +59,7 @@ export function scroll(activity: ScrollMapInfo[], avgFold: number): void {
     var de = doc.documentElement;
     var height = Math.max( body.scrollHeight, body.offsetHeight, 
         de.clientHeight, de.scrollHeight, de.offsetHeight );
-    canvas.height = Math.min(height, Setting.CanvasMaxHeight);
+    canvas.height = Math.min(height, Setting.ScrollCanvasMaxHeight);
     if (canvas.width > 0 && canvas.height > 0) {
         if (scrollData) {
             const grd = context.createLinearGradient(0, 0, 0, canvas.height);

--- a/packages/clarity-visualize/src/layout.ts
+++ b/packages/clarity-visualize/src/layout.ts
@@ -6,16 +6,30 @@ const TIMEOUT = 3000;
 let stylesheets: Promise<void>[] = [];
 let nodes = {};
 let events = {};
+let documentFragments = [];
 
 export function reset(): void {
     nodes = {};
     stylesheets = [];
     events = {};
+    documentFragments = [];
 }
 
-export function get(hash: string): Element {
+export function get(hash) {
     let doc = state.window.document;
-    return doc.querySelector(`[${Constant.Hash}="${hash}"]`);
+    let element = doc.querySelector(`[${Constant.Hash}="${hash}"]`);
+    if (!element && documentFragments.length > 0) {
+        for(var i = 0; i < documentFragments.length; i++) {
+            let documentFragment = documentFragments[i];
+            if (documentFragment) {
+                element = documentFragment.querySelector(`[${Constant.Hash}="${hash}"]`);
+                if (element) {
+                    break;
+                }
+            }
+        }
+    }
+    return element;
 }
 
 export function box(event: Layout.BoxEvent): void {
@@ -57,8 +71,7 @@ export async function dom(event: Layout.DomEvent): Promise<void> {
 
 export function exists(hash: string): boolean {
     if (hash) {
-        let doc = state.window.document;
-        let match = doc.querySelector(`[${Constant.Hash}="${hash}"]`);
+        let match = get(hash);
         if (match) {
             let rectangle = match.getBoundingClientRect();
             return rectangle && rectangle.width > 0 && rectangle.height > 0;
@@ -116,6 +129,7 @@ export function markup(event: Layout.DomEvent): void {
                         shadowRoot.appendChild(shadowStyle);
                     }
                     nodes[node.id] = shadowRoot;
+                    documentFragments.push(shadowRoot);
                 }
                 break;
             case Layout.Constant.TextTag:

--- a/packages/clarity-visualize/src/layout.ts
+++ b/packages/clarity-visualize/src/layout.ts
@@ -28,6 +28,13 @@ export function box(event: Layout.BoxEvent): void {
     }
 }
 
+function addToHashMap(hash, node)
+{
+    // In case of selector collision, prefer the first inserted node
+    let element = get(hash)
+    hashMap[hash] = element ? element : node;
+}
+
 function resize(el: HTMLElement, width: number, height: number): void {
     if (el && el.nodeType === NodeType.ELEMENT_NODE && width && height) {
         el.style.width = width + Layout.Constant.Pixel;
@@ -99,7 +106,7 @@ export function markup(event: Layout.DomEvent): void {
                 // In case of polyfill, map shadow dom to it's parent for rendering purposes
                 // All its children should be inserted as regular children to the parent node.
                 nodes[node.id] = parent;
-                hashMap[node.hash] = parent;
+                addToHashMap(node.hash, parent);
                 break;
             case Layout.Constant.ShadowDomTag:
                 if (parent) {
@@ -118,7 +125,7 @@ export function markup(event: Layout.DomEvent): void {
                         shadowRoot.appendChild(shadowStyle);
                     }
                     nodes[node.id] = shadowRoot;
-                    hashMap[node.hash] = shadowRoot;
+                    addToHashMap(node.hash, shadowRoot);
                 }
                 break;
             case Layout.Constant.TextTag:
@@ -149,7 +156,7 @@ export function markup(event: Layout.DomEvent): void {
                     // If we are still processing discover events, keep the markup hidden until we are done
                     if (type === Data.Event.Discover) { htmlDoc.documentElement.style.visibility = Constant.Hidden; }
                     nodes[node.id] = htmlDoc.documentElement;
-                    hashMap[node.hash] = htmlDoc.documentElement;
+                    addToHashMap(node.hash, htmlDoc.documentElement);
                 }
                 break;
             case "HEAD":
@@ -270,7 +277,7 @@ function insertBefore(data: Layout.DomData, parent: Node, node: Node, next: Node
         node.parentElement.removeChild(node);
     }
     nodes[data.id] = node;
-    hashMap[data.hash] = node;
+    addToHashMap(data.hash, node);
 }
 
 function setAttributes(node: HTMLElement, data: Layout.DomData): void {

--- a/packages/clarity-visualize/types/visualize.d.ts
+++ b/packages/clarity-visualize/types/visualize.d.ts
@@ -150,5 +150,5 @@ export const enum Setting {
     MarkerColor = "white",
     CanvasTextColor = "#323130",
     CanvasTextFont = "500 12px Segoe UI",
-    CanvasMaxHeight = 40000
+    ScrollCanvasMaxHeight = 40000
 }

--- a/packages/clarity-visualize/types/visualize.d.ts
+++ b/packages/clarity-visualize/types/visualize.d.ts
@@ -149,5 +149,6 @@ export const enum Setting {
     MarkerPadding = 5,
     MarkerColor = "white",
     CanvasTextColor = "#323130",
-    CanvasTextFont = "500 12px Segoe UI"
+    CanvasTextFont = "500 12px Segoe UI",
+    CanvasMaxHeight = 40000
 }


### PR DESCRIPTION
Fixes the following issues 
1. Heatmap does not work for elements inside shadow dom
2. Scroll map height is not set properly 
3. Scrollmap canvas crashes for pages with a very large height 
4.  Custom variables are overriden in some cases and appended in others
5. Add Json+LD for article headlines and creators 