### PR TITLE
Simplify selector logic in clarity-js

### DIFF
--- a/packages/clarity-decode/src/clarity.ts
+++ b/packages/clarity-decode/src/clarity.ts
@@ -37,9 +37,6 @@ export function decode(input: string): DecodedPayload {
         throw new Error(`Invalid version. Actual: ${payload.envelope.version} | Expected: ${version} (+/- 1) | ${input.substr(0, 250)}`);
     }
 
-    /* Reset components before decoding to keep them stateless */
-    layout.reset();
-
     for (let entry of encoded) {
         switch (entry[1]) {
             case Data.Event.Baseline:

--- a/packages/clarity-decode/types/layout.d.ts
+++ b/packages/clarity-decode/types/layout.d.ts
@@ -21,8 +21,8 @@ export interface DomData {
     previous: number;
     tag: string;
     position: number;
-    selector: string;
-    hash: string;
+    selector?: string;
+    hash?: string;
     attributes?: Layout.Attributes;
     value?: string;
     width?: number;

--- a/packages/clarity-devtools/static/panel.html
+++ b/packages/clarity-devtools/static/panel.html
@@ -109,7 +109,7 @@
 <body>
   <div id="info"><span>Activating Clarity</span><div class="loader"></div></div>
   <div id="header"></div>
-  <div id="download"><a href="#">Encoded Data (Session)</a> | <a href="#">Decoded Data (Page)</a></div>
+  <div id="download"><a href="#">Encoded Data (Session)</a> | <a href="#">Decoded Data (Page)</a> | <a href="#">Merged Data (Page)</a></div>
   <iframe id="clarity" title="Clarity Inspector" scrolling="no"></iframe>
   <script src="panel.js"></script>
 </body>

--- a/packages/clarity-js/src/layout/dom.ts
+++ b/packages/clarity-js/src/layout/dom.ts
@@ -329,12 +329,7 @@ export function has(node: Node): boolean {
 export function updates(): NodeValue[] {
     let output = [];
     for (let id of updateMap) {
-        if (id in values) {
-            let v = values[id];
-            let p = v.parent;
-            v.data.path = p === null || updateMap.indexOf(p) >= 0 || v.selector.length === 0 ? null : values[p].selector;
-            output.push(values[id]);
-        }
+        if (id in values) { output.push(values[id]); }
     }
     updateMap = [];
     return output;

--- a/packages/clarity-js/src/layout/encode.ts
+++ b/packages/clarity-js/src/layout/encode.ts
@@ -60,7 +60,7 @@ export default async function (type: Event, timer: Timer = null, ts: number = nu
                     let active = value.metadata.active;
                     let privacy = value.metadata.privacy;
                     let mangle = shouldMangle(value);
-                    let keys = active ? ["tag", "path", "attributes", "value"] : ["tag"];
+                    let keys = active ? ["tag", "attributes", "value"] : ["tag"];
                     box.compute(value.id);
                     for (let key of keys) {
                         if (data[key]) {
@@ -73,9 +73,6 @@ export default async function (type: Event, timer: Timer = null, ts: number = nu
                                     if (value.previous && active) { tokens.push(value.previous); }
                                     tokens.push(value.position ? `${data[key]}~${value.position}` : data[key]);
                                     if (size && size.length === 2) { tokens.push(`${Constant.Box}${str(size[0])}.${str(size[1])}`); }
-                                    break;
-                                case "path":
-                                    tokens.push(`${value.data.path}>`);
                                     break;
                                 case "attributes":
                                     for (let attr in data[key]) {

--- a/packages/clarity-js/types/layout.d.ts
+++ b/packages/clarity-js/types/layout.d.ts
@@ -129,7 +129,6 @@ export interface Attributes {
 
 export interface NodeInfo {
     tag: string;
-    path?: string;
     attributes?: Attributes;
     value?: string;
 }


### PR DESCRIPTION
- Stop sending raw selector as part of clarity-js
- Move selector and hash enrichment from clarity-decode to clarity-visualize
- Performance improvement by reducing bytes sent over the wire.
- Enable easier updates to selector logic by simplifying selector handling in clarity-js