### PR TITLE
feat: support render heatmap without visualize.dom

### DIFF
--- a/packages/clarity-visualize/src/heatmap.ts
+++ b/packages/clarity-visualize/src/heatmap.ts
@@ -236,7 +236,7 @@ function transform(): Heatmap[] {
     let localMax = 0;
     let height = state.window && state.window.document ? state.window.document.documentElement.clientHeight : 0;
     for (let element of data) {
-        let el = layout.get(element.hash) as HTMLElement;
+        let el = layout.get(element.hash, element.selector);
         if (el && typeof el.getBoundingClientRect === "function") {
             let r = el.getBoundingClientRect();
             let v = visible(el, r, height);

--- a/packages/clarity-visualize/src/layout.ts
+++ b/packages/clarity-visualize/src/layout.ts
@@ -15,8 +15,13 @@ export function reset(): void {
     hashMap = {};
 }
 
-export function get(hash) {
-    var element = hash in hashMap ? (hashMap[hash].isConnected ? hashMap[hash] : null) : null;
+export function get(hash: string, selector?: string): HTMLElement {
+    let element = hash in hashMap ? (hashMap[hash].isConnected ? hashMap[hash] : null) : null;
+
+    if (!element && selector) {
+        element = state.window.document.querySelector(selector);
+    }
+
     return element;
 }
 


### PR DESCRIPTION
If `visualize.dom` is not called previously, we failed to render heatmap because we don't have the hash map. This change is to fallback to use `selector` if cannot look up the element by `hash`.