### PR TITLE
expose project id

### DIFF
--- a/packages/clarity-js/src/clarity.ts
+++ b/packages/clarity-js/src/clarity.ts
@@ -10,7 +10,7 @@ import * as interaction from "@src/interaction";
 import * as layout from "@src/layout";
 import * as performance from "@src/performance";
 export { version };
-export { consent, event, identify, set, upgrade, metadata } from "@src/data";
+export { consent, event, identify, set, upgrade, metadata, projectId } from "@src/data";
 
 const modules: Module[] = [diagnostic, layout, interaction, performance];
 

--- a/packages/clarity-js/src/data/index.ts
+++ b/packages/clarity-js/src/data/index.ts
@@ -41,3 +41,5 @@ export function compute(): void {
     summary.compute();
     limit.compute();
 }
+
+export const projectId = () => metadata.data?.projectId;


### PR DESCRIPTION
Adding `window.clarity("projectId")` to return `projectId`.

Use case: for extension to know the projectId a given website is associated with