### PR TITLE
Update envelope

### DIFF
--- a/packages/clarity-decode/src/data.ts
+++ b/packages/clarity-decode/src/data.ts
@@ -89,6 +89,7 @@ export function envelope(tokens: Data.Token[]): Data.Envelope {
         sessionId: tokens[6] as string,
         pageNum: tokens[7] as number,
         upload: tokens[8] as Data.Upload,
-        end: tokens[9] as Data.BooleanFlag
+        end: tokens[9] as Data.BooleanFlag,
+        applicationPlatform: tokens[10] as Data.ApplicationPlatform
     };
 }

--- a/packages/clarity-js/src/data/envelope.ts
+++ b/packages/clarity-js/src/data/envelope.ts
@@ -1,4 +1,4 @@
-import { BooleanFlag, Token, Upload, Envelope } from "@clarity-types/data";
+import { BooleanFlag, Token, Upload, Envelope, ApplicationPlatform } from "@clarity-types/data";
 import { time } from "@src/core/time";
 import version from "@src/core/version";
 import * as metadata from "@src/data/metadata";
@@ -17,7 +17,8 @@ export function start(): void {
     sessionId: m.sessionId,
     pageNum: m.pageNum,
     upload: Upload.Async,
-    end: BooleanFlag.False
+    end: BooleanFlag.False,
+    applicationPlatform: ApplicationPlatform.WebApp,
   };
 }
 
@@ -41,6 +42,7 @@ export function envelope(last: boolean): Token[] {
     data.sessionId,
     data.pageNum,
     data.upload,
-    data.end
+    data.end,
+    data.applicationPlatform,
   ];
 }

--- a/packages/clarity-js/src/data/metadata.ts
+++ b/packages/clarity-js/src/data/metadata.ts
@@ -1,5 +1,5 @@
 import { Time } from "@clarity-types/core";
-import { BooleanFlag, Constant, Dimension, Metadata, MetadataCallback, MetadataCallbackOptions, Metric, Session, User, Setting } from "@clarity-types/data";
+import { BooleanFlag, Constant, Dimension, Metadata, MetadataCallback, MetadataCallbackOptions, Metric, Session, User, Setting, ApplicationPlatform } from "@clarity-types/data";
 import * as core from "@src/core";
 import config from "@src/core/config";
 import hash from "@src/core/hash";
@@ -23,7 +23,8 @@ export function start(): void {
     projectId: config.projectId || hash(location.host),
     userId: u.id,
     sessionId: s.session,
-    pageNum: s.count
+    pageNum: s.count,
+    applicationPlatform: ApplicationPlatform.WebApp
   }
 
   // Override configuration based on what's in the session storage, unless it is blank (e.g. using upload callback, like in devtools)

--- a/packages/clarity-js/types/data.d.ts
+++ b/packages/clarity-js/types/data.d.ts
@@ -170,6 +170,10 @@ export const enum BooleanFlag {
     True = 1
 }
 
+export const enum ApplicationPlatform {
+    WebApp = 0, // Clarity for web.
+}
+
 export const enum Setting {
     Expire = 365, // 1 Year
     SessionExpire = 1, // 1 Day
@@ -293,6 +297,7 @@ export interface Metadata {
     userId: string;
     sessionId: string;
     pageNum: number;
+    applicationPlatform: ApplicationPlatform;
 }
 
 export interface Session {


### PR DESCRIPTION
A new field in envelope is introduced in backend called `ApplicationPlatform`.
This field is mainly to identify the platform of the application which invoked collect API. The useability of such a field comes with introducing new Clarity Platforms, e.g., Clarity for Android Apps, IOS Apps, Desktop Apps and so on. 