### PR TITLE
add timeout to document dimensions computing in order to be executed after all the changes in the dom are done

### DIFF
--- a/packages/clarity-js/src/core/timeout.ts
+++ b/packages/clarity-js/src/core/timeout.ts
@@ -1,7 +1,7 @@
 import { Event } from "@clarity-types/data";
 import measure from "./measure";
 
-export function setTimeout(handler: (event?: Event | boolean) => void, timeout: number, event?: Event): number {
+export function setTimeout(handler: (event?: Event | boolean) => void, timeout?: number, event?: Event): number {
     return window.setTimeout(measure(handler), timeout, event);
 }
 

--- a/packages/clarity-js/src/layout/mutation.ts
+++ b/packages/clarity-js/src/layout/mutation.ts
@@ -114,7 +114,7 @@ function handle(m: MutationRecord[]): void {
   summary.track(Event.Mutation, now);
   mutations.push({ time: now, mutations: m});
   task.schedule(process, Priority.High).then((): void => {
-      measure(doc.compute)();
+      setTimeout(doc.compute)
       measure(region.compute)();
   });
 }


### PR DESCRIPTION
Added timeout to the document dimensions computing function. This function is called after the mutation is processed. this timeout without delays is added in order for this function to be at the end of the queue and executes after all the changes in the dom are done
https://stackoverflow.com/questions/19815810/avoiding-html-document-reflows
https://gist.github.com/paulirish/5d52fb081b3570c81e3a