### PR TITLE
Account for svg:style when masking

### DIFF
--- a/packages/clarity-js/src/layout/dom.ts
+++ b/packages/clarity-js/src/layout/dom.ts
@@ -239,7 +239,8 @@ function privacy(node: Node, value: NodeValue, parent: NodeValue): void {
             // If it's a text node belonging to a STYLE or TITLE tag or one of SCRUB_EXCEPTIONS, then capture content
             let pTag = parent && parent.data ? parent.data.tag : Constant.Empty;
             let pSelector = parent && parent.selector ? parent.selector[Selector.Stable] : Constant.Empty;
-            metadata.privacy = pTag === Constant.StyleTag || pTag === Constant.TitleTag || override.some(x => pSelector.indexOf(x) >= 0) ? Privacy.None : current; 
+            const styleOrTitleTags: string[] = [Constant.StyleTag, Constant.TitleTag, Constant.SvgStyle]
+            metadata.privacy = styleOrTitleTags.includes(pTag) || override.some(x => pSelector.indexOf(x) >= 0) ? Privacy.None : current; 
             break;
         case Constant.Type in attributes:
             // If this node has an explicit type assigned to it, go through masking rules to determine right privacy setting

--- a/packages/clarity-js/types/layout.d.ts
+++ b/packages/clarity-js/types/layout.d.ts
@@ -91,7 +91,8 @@ export const enum Constant {
     Content = "content",
     Generator = "generator",
     ogType = "og:type",
-    ogTitle = "og:title"
+    ogTitle = "og:title",
+    SvgStyle = "svg:style"
 }
 
 export const enum JsonLD { 


### PR DESCRIPTION
Exclude svg:style children text nodes from masking. hence will be treated like style and title tags