### PR TITLE
Fix timeout callbacks with undefined arguments 

### DIFF
--- a/packages/clarity-js/src/core/timeout.ts
+++ b/packages/clarity-js/src/core/timeout.ts
@@ -2,7 +2,7 @@ import { Event } from "@clarity-types/data";
 import measure from "./measure";
 
 export function setTimeout(handler: (event?: Event | boolean) => void, timeout?: number, event?: Event): number {
-    return window.setTimeout(measure(handler), timeout, event);
+    return window.setTimeout(() => measure(handler)(event), timeout);
 }
 
 export function clearTimeout(handle: number): void {


### PR DESCRIPTION
- fixed an issue where in some cases the callback function in the timeout is passed with different or missing arguments. this is caused due to the change of the context. I've created a wrapper for the callback with the arguments directly passed as parameters