### PR TITLE
Added pathname in order to correctly load relative path address.

### DIFF
--- a/packages/clarity-js/src/layout/node.ts
+++ b/packages/clarity-js/src/layout/node.ts
@@ -127,10 +127,21 @@ export default function (node: Node, source: Source): Node {
                     break;
                 case "HEAD":
                     let head = { tag, attributes };
-                    if (location) {
+                    let baseTags = element.getElementsByTagName("BASE");
+                    let alreadyHasBaseTag = baseTags.length > 0;
+                    if (alreadyHasBaseTag) {
+                        head.attributes[Constant.Base] = baseTags[0].attributes.getNamedItem("href").value;
+                    } else if (insideFrame && node.ownerDocument?.location) {
+                        let iframeLocation = node.ownerDocument.location;
+                        head.attributes[Constant.Base] = iframeLocation.protocol + "//"+
+                            iframeLocation.hostname + iframeLocation.pathname;
+                    } else if (location) {
                         head.attributes[Constant.Base] = location.protocol + "//" + location.hostname + location.pathname;
                     }
                     dom[call](node, parent, head, source);
+                    break;
+                case "BASE":
+                    // The base tag is handled while reading the HEAD tag
                     break;
                 case "STYLE":
                     let styleData = { tag, attributes, value: getStyleValue(element as HTMLStyleElement) };

--- a/packages/clarity-js/src/layout/node.ts
+++ b/packages/clarity-js/src/layout/node.ts
@@ -127,7 +127,9 @@ export default function (node: Node, source: Source): Node {
                     break;
                 case "HEAD":
                     let head = { tag, attributes };
-                    if (location) { head.attributes[Constant.Base] = location.protocol + "//" + location.hostname; }
+                    if (location) {
+                        head.attributes[Constant.Base] = location.protocol + "//" + location.hostname + location.pathname;
+                    }
                     dom[call](node, parent, head, source);
                     break;
                 case "STYLE":


### PR DESCRIPTION
## Fixes #279

It may be related to issues #208, #254 and #279 as well.

## PR Type

What kind of change does this PR introduce?

Bugfix

## What is the current behavior?

As described at the issue #279, Clarity is not accessing relative address correcly.

I believe this is happening because currently, clarity is always creating a base tag with the base address of the page.

When a page doesn't have a `<base>` tag, browsers will always access relative resources through the page full path (not the base url).

## What is the new behavior?

- A base tag will only be added in case the page does not contains one.
- When loading iframes, it will add the iframe 'src' value as base tag (in case the iframe does not  contains a base tag).
- When there's no base tag, a tag will be added with the full path, in order to correctly replicate browsers behavior (when there is no base tag).

## Other information

I've tested with my project (that has been struggling with the issue) and it worked correctly, rendering all styles properly. 🙃 
