### PR TITLE
Remove node if its parentElement is null

### DIFF
--- a/packages/clarity-visualize/src/layout.ts
+++ b/packages/clarity-visualize/src/layout.ts
@@ -278,7 +278,10 @@ export class LayoutHelper {
             }
         } else if (parent === null && node.parentElement !== null) {
             node.parentElement.removeChild(node);
+        } else if (parent === null && node.parentNode !== null) {
+            node.parentNode.removeChild(node);
         }
+        
         this.nodes[data.id] = node;
         this.addToHashMap(data, node);
     }


### PR DESCRIPTION
Sometimes the node's parent is not an HTML element (e.g., fragments). In these cases removing the child node would not take place. To fix this, we can remove the child from the `parentNode` instead.