### PR TITLE
fix(clarity-js): replaces hostname with host containing port

### DIFF
--- a/packages/clarity-js/src/layout/node.ts
+++ b/packages/clarity-js/src/layout/node.ts
@@ -128,7 +128,7 @@ export default function (node: Node, source: Source): Node {
                 case "HEAD":
                     let head = { tag, attributes };
                     let l = insideFrame && node.ownerDocument?.location ? node.ownerDocument.location : location;
-                    head.attributes[Constant.Base] = l.protocol + "//" + l.hostname + l.pathname;
+                    head.attributes[Constant.Base] = l.protocol + "//" + l.host + l.pathname;
                     dom[call](node, parent, head, source);
                     break;
                 case "BASE":
@@ -138,7 +138,7 @@ export default function (node: Node, source: Source): Node {
                         // We create "a" element so we can generate protocol and hostname for relative paths like "/path/"
                         let a = document.createElement("a");
                         a.href = attributes["href"];
-                        baseHead.data.attributes[Constant.Base] = a.protocol + "//" + a.hostname + a.pathname;
+                        baseHead.data.attributes[Constant.Base] = a.protocol + "//" + a.host + a.pathname;
                     }
                     break;
                 case "STYLE":

--- a/packages/clarity-js/src/performance/observer.ts
+++ b/packages/clarity-js/src/performance/observer.ts
@@ -91,5 +91,5 @@ export function stop(): void {
 function host(url: string): string {
     let a = document.createElement("a");
     a.href = url;
-    return a.hostname;
+    return a.host;
 }


### PR DESCRIPTION
This pull request proposes some changes to improve the functionality of clarity-js on websites deployed on ports different than port 80 and port 443.

Currently, version 0.7.4 of clarity-js does not work properly on websites deployed on ports other than 80 and 443. For instance, when using clarity-js on a website deployed on port 8443, recordings and heatmaps won't work properly because clarity will try to download static assets from `example.com` instead of `example.com:8443`.

After reviewing the code, I found out that `hostname` was used in three instances instead of host, which causes the issues described above. Therefore, this pull request suggests replacing `hostname` with host in the relevant code blocks.

The proposed changes are backwards compatible because if no port is specified, `host` will have the same value as `hostname`.