### PR TITLE
Remove integrity attribute for proxy <link />, potential fix for CSS sub-resources integrity.

### DIFF
--- a/packages/clarity-visualize/src/layout.ts
+++ b/packages/clarity-visualize/src/layout.ts
@@ -190,7 +190,13 @@ export class LayoutHelper {
                         if (node.attributes["rel"] === "stylesheet") {
                             this.stylesheets.push(new Promise((resolve: () => void): void => {
                                 const proxy = useproxy ?? this.state.options.useproxy;
-                                linkElement.href = proxy ? proxy(linkElement.href) : linkElement.href;
+                                if (proxy) {
+                                    if (linkElement.integrity) {
+                                        linkElement.removeAttribute('integrity');
+                                    }
+
+                                    linkElement.href = proxy(linkElement.href);
+                                } 
                                 linkElement.onload = linkElement.onerror = this.style.bind(this, linkElement, resolve);
                                 setTimeout(resolve, LayoutHelper.TIMEOUT);
                             }));


### PR DESCRIPTION
May related to #278, #329, or any project build with webpack/angular or have external font URL in the CSS file.

The CSS files caching with URL `https://clarity.microsoft.com/external/v2/resources?url={url}` (1) have the content replaced with external resource URL but *SHA-384 integrity* itself aren't updated, causing resource blocked by browser.

You can run diff check on the URL (1) and original URL on any CSS file with `@font-face { src: url(...) }`.

Or play any recording which has CSS issue, then open DevTools (F12), go to Console, then paste the following:
```js
document.querySelector('#clarity-snapshot-iframe')
  .contentDocument.querySelectorAll('link[integrity]')
  .forEach(ln => {
    ln.removeAttribute('integrity');
    ln.href= ln.href;
  });
```