### PR TITLE
Fix large timestamp values

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.7.10",
+  "version": "0.7.11",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clarity",
   "private": true,
-  "version": "0.7.10",
+  "version": "0.7.11",
   "repository": "https://github.com/microsoft/clarity.git",
   "author": "Sarvesh Nagpal <sarveshn@microsoft.com>",
   "license": "MIT",

--- a/packages/clarity-decode/package.json
+++ b/packages/clarity-decode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-decode",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-js": "^0.7.10"
+    "clarity-js": "^0.7.11"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",

--- a/packages/clarity-devtools/package.json
+++ b/packages/clarity-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-devtools",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "private": true,
   "description": "Adds Clarity debugging support to browser devtools",
   "author": "Microsoft Corp.",
@@ -24,9 +24,9 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.7.10",
-    "clarity-js": "^0.7.10",
-    "clarity-visualize": "^0.7.10"
+    "clarity-decode": "^0.7.11",
+    "clarity-js": "^0.7.11",
+    "clarity-visualize": "^0.7.11"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.0",

--- a/packages/clarity-devtools/static/manifest.json
+++ b/packages/clarity-devtools/static/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 2,
   "name": "Microsoft Clarity Developer Tools",
   "description": "Clarity helps you understand how users are interacting with your website.",
-  "version": "0.7.10",
-  "version_name": "0.7.10",
+  "version": "0.7.11",
+  "version_name": "0.7.11",
   "minimum_chrome_version": "50",
   "devtools_page": "devtools.html",
   "icons": {

--- a/packages/clarity-js/package.json
+++ b/packages/clarity-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/packages/clarity-js/src/core/time.ts
+++ b/packages/clarity-js/src/core/time.ts
@@ -5,7 +5,7 @@ export function start(): void {
 }
 
 export function time(event: UIEvent = null): number {
-    let ts = event && event.timeStamp > 0 ? event.timeStamp : performance.now();
+    let ts = performance.now();
     return Math.max(Math.round(ts - startTime), 0);
 }
 

--- a/packages/clarity-js/src/core/version.ts
+++ b/packages/clarity-js/src/core/version.ts
@@ -1,2 +1,2 @@
-let version = "0.7.10";
+let version = "0.7.11";
 export default version;

--- a/packages/clarity-visualize/package.json
+++ b/packages/clarity-visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-visualize",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.7.10"
+    "clarity-decode": "^0.7.11"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",


### PR DESCRIPTION
In some old browsers, some events timestamps are set to absolute timestamps causing overflow exceptions. This fix suggests depending on "performance.now()" in all cases to solve this issue.