### PR TITLE
Uri encode cookie values for compatibility with certain mobile browsers

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.7.16",
+  "version": "0.7.17",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clarity",
   "private": true,
-  "version": "0.7.16",
+  "version": "0.7.17",
   "repository": "https://github.com/microsoft/clarity.git",
   "author": "Sarvesh Nagpal <sarveshn@microsoft.com>",
   "license": "MIT",

--- a/packages/clarity-decode/package.json
+++ b/packages/clarity-decode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-decode",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-js": "^0.7.16"
+    "clarity-js": "^0.7.17"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",

--- a/packages/clarity-devtools/package.json
+++ b/packages/clarity-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-devtools",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "private": true,
   "description": "Adds Clarity debugging support to browser devtools",
   "author": "Microsoft Corp.",
@@ -24,9 +24,9 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.7.16",
-    "clarity-js": "^0.7.16",
-    "clarity-visualize": "^0.7.16"
+    "clarity-decode": "^0.7.17",
+    "clarity-js": "^0.7.17",
+    "clarity-visualize": "^0.7.17"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.0",

--- a/packages/clarity-devtools/static/manifest.json
+++ b/packages/clarity-devtools/static/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 2,
   "name": "Microsoft Clarity Developer Tools",
   "description": "Clarity helps you understand how users are interacting with your website.",
-  "version": "0.7.16",
-  "version_name": "0.7.16",
+  "version": "0.7.17",
+  "version_name": "0.7.17",
   "minimum_chrome_version": "50",
   "devtools_page": "devtools.html",
   "icons": {

--- a/packages/clarity-js/package.json
+++ b/packages/clarity-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/packages/clarity-js/src/core/version.ts
+++ b/packages/clarity-js/src/core/version.ts
@@ -1,2 +1,2 @@
-let version = "0.7.16";
+let version = "0.7.17";
 export default version;

--- a/packages/clarity-js/src/data/metadata.ts
+++ b/packages/clarity-js/src/data/metadata.ts
@@ -282,12 +282,12 @@ function setCookie(key: string, value: string, time: number): void {
   if (config.track && ((navigator && navigator.cookieEnabled) || supported(document, Constant.Cookie))) {
     // Some browsers automatically url encode cookie values if they are not url encoded.
     // We therefore encode and decode cookie values ourselves.
-    value = encodeCookieValue(value);
+    let encodedValue = encodeCookieValue(value);
 
     let expiry = new Date();
     expiry.setDate(expiry.getDate() + time);
     let expires = expiry ? Constant.Expires + expiry.toUTCString() : Constant.Empty;
-    let cookie = `${key}=${value}${Constant.Semicolon}${expires}${Constant.Path}`;
+    let cookie = `${key}=${encodedValue}${Constant.Semicolon}${expires}${Constant.Path}`;
     try {
       // Attempt to get the root domain only once and fall back to writing cookie on the current domain.
       if (rootDomain === null) {

--- a/packages/clarity-js/src/data/metadata.ts
+++ b/packages/clarity-js/src/data/metadata.ts
@@ -272,7 +272,7 @@ function decodeCookieValue(value: string): string {
 
 function valueIsEncoded(value: string): [boolean, string] {
   try {
-    let decodedValue = decodeURI(value);
+    let decodedValue = decodeURIComponent(value);
     return [decodedValue != value, decodedValue];
   }
   catch {
@@ -282,7 +282,7 @@ function valueIsEncoded(value: string): [boolean, string] {
 }
 
 function encodeCookieValue(value: string): string {
-  return encodeURI(value);
+  return encodeURIComponent(value);
 }
 
 function setCookie(key: string, value: string, time: number): void {

--- a/packages/clarity-js/src/data/metadata.ts
+++ b/packages/clarity-js/src/data/metadata.ts
@@ -19,7 +19,7 @@ export function start(): void {
   const ua = navigator && "userAgent" in navigator ? navigator.userAgent : Constant.Empty;
   const title = document && document.title ? document.title : Constant.Empty;
   electron = ua.indexOf(Constant.Electron) > 0 ? BooleanFlag.True : BooleanFlag.False;
-  
+
   // Populate ids for this page
   let s = session();
   let u = user();
@@ -75,7 +75,7 @@ export function start(): void {
 function userAgentData(): void {
   let uaData = navigator["userAgentData"];
   if (uaData && uaData.getHighEntropyValues) {
-    uaData.getHighEntropyValues(["model","platform","platformVersion","uaFullVersion"]).then(ua => {
+    uaData.getHighEntropyValues(["model", "platform", "platformVersion", "uaFullVersion"]).then(ua => {
       dimension.log(Dimension.Platform, ua.platform);
       dimension.log(Dimension.PlatformVersion, ua.platformVersion);
       ua.brands?.forEach(brand => { dimension.log(Dimension.Brand, brand.name + Constant.Tilde + brand.version); });
@@ -99,7 +99,7 @@ export function metadata(cb: MetadataCallback, wait: boolean = true): void {
     // Immediately invoke the callback if the caller explicitly doesn't want to wait for the upgrade confirmation
     cb(data, !config.lean);
   } else {
-    callbacks.push({callback: cb, wait: wait });
+    callbacks.push({ callback: cb, wait: wait });
   }
 }
 
@@ -162,7 +162,7 @@ function track(u: User, consent: BooleanFlag = null): void {
   consent = consent === null ? u.consent : consent;
   // Convert time precision into days to reduce number of bytes we have to write in a cookie
   // E.g. Math.ceil(1628735962643 / (24*60*60*1000)) => 18852 (days) => ejo in base36 (13 bytes => 3 bytes)
-  let end = Math.ceil((Date.now() + (Setting.Expire * Time.Day))/Time.Day);
+  let end = Math.ceil((Date.now() + (Setting.Expire * Time.Day)) / Time.Day);
   // If DOB is not set in the user object, use the date set in the config as a DOB
   let dob = u.dob === 0 ? (config.dob === null ? 0 : config.dob) : u.dob;
 
@@ -205,7 +205,7 @@ function num(string: string, base: number = 10): number {
 function user(): User {
   let output: User = { id: shortid(), version: 0, expiry: null, consent: BooleanFlag.False, dob: 0 };
   let cookie = getCookie(Constant.CookieKey);
-  if(cookie && cookie.length > 0) {
+  if (cookie && cookie.length > 0) {
     // Splitting and looking up first part for forward compatibility, in case we wish to store additional information in a cookie
     let parts = cookie.split(Constant.Pipe);
     // For backward compatibility introduced in v0.6.18; following code can be removed with future iterations
@@ -243,7 +243,9 @@ function getCookie(key: string): string {
       for (let i = 0; i < cookies.length; i++) {
         let pair: string[] = cookies[i].split(Constant.Equals);
         if (pair.length > 1 && pair[0] && pair[0].trim() === key) {
-          return pair[1];
+          // Some browsers automatically url encode cookie values if they are not url encoded.
+          // We therefore encode and decode cookie values ourselves.
+          return decodeCookieValue(pair[1]);
         }
       }
     }
@@ -251,8 +253,44 @@ function getCookie(key: string): string {
   return null;
 }
 
+function decodeCookieValue(value: string): string {
+  // For backwards compatability we need to consider 3 cases:
+  // * Cookie was previously not encoded by Clarity and browser did not encode it
+  // * Cookie was previously not encoded by Clarity and browser encoded it once or more
+  // * Cookie was previously encoded by Clarity and browser did not encode it
+  let [isEncoded, decodedValue] = valueIsEncoded(value);
+  if (!isEncoded) {
+    return value;
+  }
+
+  while (isEncoded) {
+    [isEncoded, decodedValue] = valueIsEncoded(decodedValue);
+  }
+
+  return decodedValue;
+}
+
+function valueIsEncoded(value: string): [boolean, string] {
+  try {
+    let decodedValue = decodeURI(value);
+    return [decodedValue != value, decodedValue];
+  }
+  catch {
+  }
+
+  return [false, value];
+}
+
+function encodeCookieValue(value: string): string {
+  return encodeURI(value);
+}
+
 function setCookie(key: string, value: string, time: number): void {
-  if (config.track && ((navigator && navigator.cookieEnabled) ||  supported(document, Constant.Cookie))) {
+  if (config.track && ((navigator && navigator.cookieEnabled) || supported(document, Constant.Cookie))) {
+    // Some browsers automatically url encode cookie values if they are not url encoded.
+    // We therefore encode and decode cookie values ourselves.
+    value = encodeCookieValue(value);
+
     let expiry = new Date();
     expiry.setDate(expiry.getDate() + time);
     let expires = expiry ? Constant.Expires + expiry.toUTCString() : Constant.Empty;

--- a/packages/clarity-visualize/package.json
+++ b/packages/clarity-visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-visualize",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.7.16"
+    "clarity-decode": "^0.7.17"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",


### PR DESCRIPTION
Some browsers automatically url encode cookie values if they are not url encoded. We fix this by always uri encoding cookies, and supporting the decoding of encoded cookies.