### PR TITLE
Enable the customization of the name of DOM elements when clicked

### DIFF
--- a/packages/clarity-js/src/interaction/click.ts
+++ b/packages/clarity-js/src/interaction/click.ts
@@ -1,6 +1,6 @@
 import { BooleanFlag, Constant, Event, Setting } from "@clarity-types/data";
 import { BrowsingContext, ClickState } from "@clarity-types/interaction";
-import { Box } from "@clarity-types/layout";
+import { Box, Constant as LayoutConstant } from "@clarity-types/layout";
 import { bind } from "@src/core/event";
 import { schedule } from "@src/core/task";
 import { time } from "@src/core/time";
@@ -89,8 +89,9 @@ function link(node: Node): HTMLAnchorElement {
 function text(element: Node): string {
     let output = null;
     if (element) {
-        // Grab text using "textContent" for most HTMLElements, however, use "value" for HTMLInputElements and "alt" for HTMLImageElement.
-        let t = element.textContent || (element as HTMLInputElement).value || (element as HTMLImageElement).alt;
+        let customText = (element as HTMLElement).getAttribute(LayoutConstant.EventData);
+        // Grab text using "EventData" attribute, or "textContent" for most HTMLElements, however, use "value" for HTMLInputElements and "alt" for HTMLImageElement.
+        let t = customText  || element.textContent || (element as HTMLInputElement).value || (element as HTMLImageElement).alt;
         if (t) {
             // Replace multiple occurrence of space characters with a single white space
             // Also, trim any spaces at the beginning or at the end of string

--- a/packages/clarity-js/types/layout.d.ts
+++ b/packages/clarity-js/types/layout.d.ts
@@ -80,6 +80,7 @@ export const enum Constant {
     MaskData = "data-clarity-mask",
     UnmaskData = "data-clarity-unmask",
     RegionData = "data-clarity-region",
+    EventData = "data-clarity-event",
     Type = "type",
     Submit = "submit",
     Name = "name",


### PR DESCRIPTION
**Objective**
Enable the customization of the name of DOM elements when clicked.

**Motivation**
**1. Independence from the content of the DOM element:** 
By using a custom attribute, the logic for event tracking is separated from the content of the element. This provides flexibility to change the content without affecting the tracking logic.

**2. Avoids internationalization issues:** 
In multilingual applications, the text of the element may change depending on the language, which could complicate tracking. A custom attribute can provide a more stable identifier.

**2. Privacy enhancement:**
There may be scenarios where an element contains sensitive information, like email, name or passwords. This enhances the masking option already provided by clarity and additionally gives the analytics more context about the action.

**How does it work?**
By using the custom attribute "**data-clarity-event**" on the clickable DOM element, this will be considered as the default event name.
If the custom attribute "**data-clarity-event**" does not exist on the element, the current logic will be followed to obtain the name (textContent, value, or alt).
