### PR TITLE
Add DeviceFamily to client Dimension

### DIFF
--- a/packages/clarity-js/types/data.d.ts
+++ b/packages/clarity-js/types/data.d.ts
@@ -143,7 +143,7 @@ export const enum Dimension {
     ConnectionType = 27,
     Dob = 28,
     CookieVersion = 29,
-    DeviceFamily = 30
+    DeviceFamily = 30 // Allows iOS SDK to override the DeviceFamily value parsed from UserAgent.
 }
 
 export const enum Check {

--- a/packages/clarity-js/types/data.d.ts
+++ b/packages/clarity-js/types/data.d.ts
@@ -142,7 +142,8 @@ export const enum Dimension {
     DevicePixelRatio = 26,
     ConnectionType = 27,
     Dob = 28,
-    CookieVersion = 29
+    CookieVersion = 29,
+    DeviceFamily = 30
 }
 
 export const enum Check {


### PR DESCRIPTION
Add a separate client dimension to be used by Apps SDKs to contain the device model e.g. Pixel 6 Pro.

Note: It's confusing but the existing Model dimension cannot be used as it's already been used to capture the device brand.