### PR TITLE
Ignoring src in media tags

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.7.23",
+  "version": "0.7.24",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/clarity-decode/package.json
+++ b/packages/clarity-decode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-decode",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-js": "^0.7.23"
+    "clarity-js": "^0.7.24"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",

--- a/packages/clarity-devtools/package.json
+++ b/packages/clarity-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-devtools",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "private": true,
   "description": "Adds Clarity debugging support to browser devtools",
   "author": "Microsoft Corp.",
@@ -24,9 +24,9 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.7.23",
-    "clarity-js": "^0.7.23",
-    "clarity-visualize": "^0.7.23"
+    "clarity-decode": "^0.7.24",
+    "clarity-js": "^0.7.24",
+    "clarity-visualize": "^0.7.24"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.0",

--- a/packages/clarity-devtools/static/manifest.json
+++ b/packages/clarity-devtools/static/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 2,
   "name": "Microsoft Clarity Developer Tools",
   "description": "Clarity helps you understand how users are interacting with your website.",
-  "version": "0.7.23",
-  "version_name": "0.7.23",
+  "version": "0.7.24",
+  "version_name": "0.7.24",
   "minimum_chrome_version": "50",
   "devtools_page": "devtools.html",
   "icons": {

--- a/packages/clarity-js/package.json
+++ b/packages/clarity-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/packages/clarity-js/src/core/version.ts
+++ b/packages/clarity-js/src/core/version.ts
@@ -1,2 +1,2 @@
-let version = "0.7.23";
+let version = "0.7.24";
 export default version;

--- a/packages/clarity-js/src/layout/node.ts
+++ b/packages/clarity-js/src/layout/node.ts
@@ -186,7 +186,7 @@ export default function (node: Node, source: Source): Node {
                 case "AUDIO":
                 case "SOURCE":
                     // Ignoring any base64 src attribute for media elements to prevent big unused tokens to be sent and shock the network 
-                    if(Constant.Src in attributes && attributes[Constant.Src].startsWith("data:")){
+                    if (Constant.Src in attributes && attributes[Constant.Src].startsWith("data:")) {
                         delete attributes[Constant.Src]
                     }
                     let mediaTag = { tag, attributes };

--- a/packages/clarity-js/src/layout/node.ts
+++ b/packages/clarity-js/src/layout/node.ts
@@ -185,8 +185,8 @@ export default function (node: Node, source: Source): Node {
                 case "VIDEO":
                 case "AUDIO":
                 case "SOURCE":
-                    // Ignoring any src attribute for media elements
-                    if(Constant.Src in attributes){
+                    // Ignoring any base64 src attribute for media elements to prevent big unused tokens to be sent and shock the network 
+                    if(Constant.Src in attributes && isBase64(attributes[Constant.Src])){
                         delete attributes[Constant.Src]
                     }
                     let mediaTag = { tag, attributes };
@@ -258,4 +258,12 @@ function getAttributes(element: HTMLElement): { [key: string]: string } {
     }
 
     return output;
+}
+
+function isBase64(base64Str: string) {
+    try {
+        return window.btoa?.(window.atob?.(base64Str)) === base64Str;
+    } catch (err) {
+        return false;
+    }
 }

--- a/packages/clarity-js/src/layout/node.ts
+++ b/packages/clarity-js/src/layout/node.ts
@@ -186,7 +186,7 @@ export default function (node: Node, source: Source): Node {
                 case "AUDIO":
                 case "SOURCE":
                     // Ignoring any base64 src attribute for media elements to prevent big unused tokens to be sent and shock the network 
-                    if(Constant.Src in attributes && isBase64(attributes[Constant.Src])){
+                    if(Constant.Src in attributes && attributes[Constant.Src].startsWith("data:")){
                         delete attributes[Constant.Src]
                     }
                     let mediaTag = { tag, attributes };
@@ -258,12 +258,4 @@ function getAttributes(element: HTMLElement): { [key: string]: string } {
     }
 
     return output;
-}
-
-function isBase64(base64Str: string) {
-    try {
-        return window.btoa?.(window.atob?.(base64Str)) === base64Str;
-    } catch (err) {
-        return false;
-    }
 }

--- a/packages/clarity-js/src/layout/node.ts
+++ b/packages/clarity-js/src/layout/node.ts
@@ -182,6 +182,16 @@ export default function (node: Node, source: Source): Node {
                     let linkData = { tag, attributes };
                     dom[call](node, parent, linkData, source);
                     break;
+                case "VIDEO":
+                case "AUDIO":
+                case "SOURCE":
+                    // Ignoring any src attribute for media elements
+                    if(Constant.Src in attributes){
+                        delete attributes[Constant.Src]
+                    }
+                    let mediaTag = { tag, attributes };
+                    dom[call](node, parent, mediaTag, source);
+                    break;
                 default:
                     let data = { tag, attributes };
                     if (element.shadowRoot) { child = element.shadowRoot; }

--- a/packages/clarity-visualize/package.json
+++ b/packages/clarity-visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-visualize",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.7.23"
+    "clarity-decode": "^0.7.24"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",


### PR DESCRIPTION
Ignoring big base64 encoded src for video and audio html tags to prevent large payload tokens and memory leaks.
Addressing [this issue](https://github.com/microsoft/clarity/issues/407#issuecomment-1992055905) 