### PR TITLE
Ensuring newly discovered nodes are appropriately tracked

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.7.38",
+  "version": "0.7.39",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clarity",
   "private": true,
-  "version": "0.7.38",
+  "version": "0.7.39",
   "repository": "https://github.com/microsoft/clarity.git",
   "author": "Sarvesh Nagpal <sarveshn@microsoft.com>",
   "license": "MIT",

--- a/packages/clarity-decode/package.json
+++ b/packages/clarity-decode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-decode",
-  "version": "0.7.38",
+  "version": "0.7.39",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-js": "^0.7.38"
+    "clarity-js": "^0.7.39"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",

--- a/packages/clarity-devtools/package.json
+++ b/packages/clarity-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-devtools",
-  "version": "0.7.38",
+  "version": "0.7.39",
   "private": true,
   "description": "Adds Clarity debugging support to browser devtools",
   "author": "Microsoft Corp.",
@@ -24,9 +24,9 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.7.38",
-    "clarity-js": "^0.7.38",
-    "clarity-visualize": "^0.7.38"
+    "clarity-decode": "^0.7.39",
+    "clarity-js": "^0.7.39",
+    "clarity-visualize": "^0.7.39"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.0",

--- a/packages/clarity-devtools/static/manifest.json
+++ b/packages/clarity-devtools/static/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 2,
   "name": "Microsoft Clarity Developer Tools",
   "description": "Clarity helps you understand how users are interacting with your website.",
-  "version": "0.7.38",
-  "version_name": "0.7.38",
+  "version": "0.7.39",
+  "version_name": "0.7.39",
   "minimum_chrome_version": "50",
   "devtools_page": "devtools.html",
   "icons": {

--- a/packages/clarity-js/package.json
+++ b/packages/clarity-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.7.38",
+  "version": "0.7.39",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/packages/clarity-js/src/core/version.ts
+++ b/packages/clarity-js/src/core/version.ts
@@ -1,2 +1,2 @@
-let version = "0.7.38";
+let version = "0.7.39";
 export default version;

--- a/packages/clarity-js/src/layout/dom.ts
+++ b/packages/clarity-js/src/layout/dom.ts
@@ -121,7 +121,7 @@ export function add(node: Node, parent: Node, data: NodeInfo, source: Source): v
     privacy(node, values[id], parentValue);
     updateSelector(values[id]);
     size(values[id]);
-    track(id, source);
+    track(id, source, true, true);
 }
 
 export function update(node: Node, parent: Node, data: NodeInfo, source: Source): void {
@@ -345,14 +345,10 @@ function remove(id: number, source: Source): void {
 function removeNodeFromNodesMap(id: number) {
     // Shadow dom roots shouldn't be deleted, 
     // we should keep listening to the mutations there even they're not rendered in the DOM.
-    var node = nodesMap.get(id);
-    if(node.nodeType === Node.DOCUMENT_FRAGMENT_NODE){
+    if(nodesMap.get(id).nodeType === Node.DOCUMENT_FRAGMENT_NODE){
         return;
     }
-    // need to ensure we delete references in our id map as well as nodes map, otherwise we can end
-    // up with inconsistent state which causes orphaned nodes to be dropped from visualization
     nodesMap.delete(id);
-    idMap.delete(node);
 
     let value = id in values ? values[id] : null;
     if (value && value.children) {
@@ -387,6 +383,6 @@ function track(id: number, source: Source, changed: boolean = true, parentChange
         updateMap.splice(uIndex, 1);
         updateMap.push(id);
     } else if (uIndex === -1 && changed) {
-         updateMap.push(id);
+        updateMap.push(id);
     }
 }

--- a/packages/clarity-js/src/layout/dom.ts
+++ b/packages/clarity-js/src/layout/dom.ts
@@ -345,10 +345,14 @@ function remove(id: number, source: Source): void {
 function removeNodeFromNodesMap(id: number) {
     // Shadow dom roots shouldn't be deleted, 
     // we should keep listening to the mutations there even they're not rendered in the DOM.
-    if(nodesMap.get(id).nodeType === Node.DOCUMENT_FRAGMENT_NODE){
+    var node = nodesMap.get(id);
+    if(node.nodeType === Node.DOCUMENT_FRAGMENT_NODE){
         return;
     }
+    // need to ensure we delete references in our id map as well as nodes map, otherwise we can end
+    // up with inconsistent state which causes orphaned nodes to be dropped from visualization
     nodesMap.delete(id);
+    idMap.delete(node);
 
     let value = id in values ? values[id] : null;
     if (value && value.children) {
@@ -382,5 +386,7 @@ function track(id: number, source: Source, changed: boolean = true, parentChange
     if (uIndex >= 0 && source === Source.ChildListAdd && parentChanged) {
         updateMap.splice(uIndex, 1);
         updateMap.push(id);
-    } else if (uIndex === -1 && changed) { updateMap.push(id); }
+    } else if (uIndex === -1 && changed) {
+         updateMap.push(id);
+    }
 }

--- a/packages/clarity-visualize/package.json
+++ b/packages/clarity-visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-visualize",
-  "version": "0.7.38",
+  "version": "0.7.39",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.7.38"
+    "clarity-decode": "^0.7.39"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",


### PR DESCRIPTION
lest we have a dangling reference that can break visualization when node is reused