### PR TITLE
Fix metadata callbacks for long/multiple sessions

### DIFF
--- a/packages/clarity-js/types/data.d.ts
+++ b/packages/clarity-js/types/data.d.ts
@@ -6,7 +6,8 @@ export type DecodedToken = (any | any[]);
 export type MetadataCallback = (data: Metadata, playback: boolean) => void;
 export interface MetadataCallbackOptions {
     callback: MetadataCallback,
-    wait: boolean
+    wait: boolean,
+    called: boolean
 }
 export type SignalCallback = (data: ClaritySignal) => void
 

--- a/packages/clarity-js/types/data.d.ts
+++ b/packages/clarity-js/types/data.d.ts
@@ -7,6 +7,7 @@ export type MetadataCallback = (data: Metadata, playback: boolean) => void;
 export interface MetadataCallbackOptions {
     callback: MetadataCallback,
     wait: boolean,
+    recall: boolean,
     called: boolean
 }
 export type SignalCallback = (data: ClaritySignal) => void


### PR DESCRIPTION
Metadata callbacks with `!wait` flag are executed once and not added to the list of callbacks in case another session starts for the same page.