### PR TITLE
Add flag for click text length

### DIFF
--- a/packages/clarity-decode/src/interaction.ts
+++ b/packages/clarity-decode/src/interaction.ts
@@ -36,7 +36,8 @@ export function decode(tokens: Data.Token[]): InteractionEvent {
                 link: tokens[11] as string,
                 hash: clickHashes[0],
                 hashBeta: clickHashes.length > 0 ? clickHashes[1] : null,
-                trust: tokens.length > 13 ? tokens[13] as number : Data.BooleanFlag.True
+                trust: tokens.length > 13 ? tokens[13] as number : Data.BooleanFlag.True,
+                isFullText: tokens.length > 14 ? tokens[14] as number : null,
             };
             return { time, event, data: clickData };
         case Data.Event.Clipboard:

--- a/packages/clarity-js/src/interaction/click.ts
+++ b/packages/clarity-js/src/interaction/click.ts
@@ -1,5 +1,5 @@
 import { BooleanFlag, Constant, Event, Setting } from "@clarity-types/data";
-import { BrowsingContext, ClickState } from "@clarity-types/interaction";
+import { BrowsingContext, ClickState, TextInfo } from "@clarity-types/interaction";
 import { Box } from "@clarity-types/layout";
 import { FunctionNames } from "@clarity-types/performance";
 import { bind } from "@src/core/event";
@@ -55,6 +55,7 @@ function handler(event: Event, root: Node, evt: MouseEvent): void {
 
     // Check for null values before processing this event
     if (x !== null && y !== null) {
+        const textInfo = text(t);
         state.push({
             time: time(evt), event, data: {
                 target: t,
@@ -65,10 +66,11 @@ function handler(event: Event, root: Node, evt: MouseEvent): void {
                 button: evt.button,
                 reaction: reaction(t),
                 context: context(a),
-                text: text(t),
+                text: textInfo.text,
                 link: a ? a.href : null,
                 hash: null,
-                trust: evt.isTrusted ? BooleanFlag.True : BooleanFlag.False
+                trust: evt.isTrusted ? BooleanFlag.True : BooleanFlag.False,
+                isFullText: textInfo.isFullText,
             }
         });
         schedule(encode.bind(this, event));
@@ -88,19 +90,23 @@ function link(node: Node): HTMLAnchorElement {
     return null;
 }
 
-function text(element: Node): string {
+function text(element: Node): TextInfo {
     let output = null;
+    let isFullText = false;
     if (element) {
         // Grab text using "textContent" for most HTMLElements, however, use "value" for HTMLInputElements and "alt" for HTMLImageElement.
         let t = element.textContent || String((element as HTMLInputElement).value || '') || (element as HTMLImageElement).alt;
         if (t) {
             // Replace multiple occurrence of space characters with a single white space
             // Also, trim any spaces at the beginning or at the end of string
+            const trimmedText =  t.replace(/\s+/g, Constant.Space).trim();
             // Finally, send only first few characters as specified by the Setting
-            output = t.replace(/\s+/g, Constant.Space).trim().substr(0, Setting.ClickText);
+            output = trimmedText.substring(0, Setting.ClickText);
+            isFullText = output.length === trimmedText.length;
         }
     }
-    return output;
+
+    return { text: output, isFullText: isFullText ? BooleanFlag.True : BooleanFlag.False };
 }
 
 function reaction(element: Node): BooleanFlag {

--- a/packages/clarity-js/src/interaction/encode.ts
+++ b/packages/clarity-js/src/interaction/encode.ts
@@ -67,6 +67,7 @@ export default async function (type: Event, ts: number = null): Promise<void> {
                 tokens.push(scrub.url(entry.data.link));
                 tokens.push(cHash);
                 tokens.push(entry.data.trust);
+                tokens.push(entry.data.isFullText);
                 queue(tokens);
                 timeline.track(entry.time, entry.event, cHash, entry.data.x, entry.data.y, entry.data.reaction, entry.data.context);
             }

--- a/packages/clarity-js/types/interaction.d.ts
+++ b/packages/clarity-js/types/interaction.d.ts
@@ -122,6 +122,12 @@ export interface ClickData {
     link: string;
     hash: string;
     trust: number;
+    isFullText: BooleanFlag;
+}
+
+export interface TextInfo {
+    text: string;
+    isFullText: BooleanFlag;
 }
 
 export interface ClipboardData {


### PR DESCRIPTION
- Add new field to denote if text is full length or partial in click event
- Updated deprecated `substr` with `substring` method