### PR TITLE
Extend baseline data to hold more pointer info

### DIFF
--- a/packages/clarity-decode/src/data.ts
+++ b/packages/clarity-decode/src/data.ts
@@ -47,6 +47,7 @@ export function decode(tokens: Data.Token[]): DataEvent {
             }
             return { time, event, data: summary };
         case Data.Event.Baseline:
+            const tokenLength = tokens.length;
             let baselineData: Data.BaselineData = {
                 visible: tokens[2] as number,
                 docWidth: tokens[3] as number,
@@ -58,14 +59,20 @@ export function decode(tokens: Data.Token[]): DataEvent {
                 pointerX: tokens[9] as number,
                 pointerY: tokens[10] as number,
                 activityTime: tokens[11] as number,
-                scrollTime: tokens.length > 12 ? tokens[12] as number: null,
-                pointerTime: tokens.length > 13 ? tokens[13] as number: null,
-                moveX: tokens.length > 14 ? tokens[14] as number: null,
-                moveY: tokens.length > 15 ? tokens[15] as number: null,
-                moveTime: tokens.length > 16 ? tokens[16] as number: null,
-                downX: tokens.length > 17 ? tokens[17] as number: null, 
-                downY: tokens.length > 18 ? tokens[18] as number: null,
-                downTime: tokens.length > 19 ? tokens[19] as number: null,
+                scrollTime: tokenLength > 12 ? tokens[12] as number: null,
+                pointerTime: tokenLength > 13 ? tokens[13] as number: null,
+                moveX: tokenLength > 14 ? tokens[14] as number: null,
+                moveY: tokenLength > 15 ? tokens[15] as number: null,
+                moveTime: tokenLength > 16 ? tokens[16] as number: null,
+                downX: tokenLength > 17 ? tokens[17] as number: null, 
+                downY: tokenLength > 18 ? tokens[18] as number: null,
+                downTime: tokenLength > 19 ? tokens[19] as number: null,
+                upX: tokenLength > 20 ? tokens[20] as number: null,
+                upY: tokenLength > 21 ? tokens[21] as number: null,
+                upTime: tokenLength > 22 ? tokens[22] as number: null,
+                pointerPrevX: tokenLength > 23 ? tokens[23] as number: null,
+                pointerPrevY: tokenLength > 24 ? tokens[24] as number: null,
+                pointerPrevTime: tokenLength > 25 ? tokens[25] as number: null,
             }
             return { time, event, data: baselineData };
         case Data.Event.Variable:

--- a/packages/clarity-js/src/data/baseline.ts
+++ b/packages/clarity-js/src/data/baseline.ts
@@ -35,6 +35,12 @@ export function reset(): void {
             downX: buffer.downX,
             downY: buffer.downY,
             downTime: buffer.downTime,
+            upX: buffer.upX,
+            upY: buffer.upY,
+            upTime: buffer.upTime,
+            pointerPrevX: buffer.pointerPrevX,
+            pointerPrevY: buffer.pointerPrevY,
+            pointerPrevTime: buffer.pointerPrevTime,
           }
         };
     }
@@ -57,6 +63,12 @@ export function reset(): void {
         downX: 0,
         downY: 0,
         downTime: 0,
+        upX: 0,
+        upY: 0,
+        upTime: 0,
+        pointerPrevX: 0,
+        pointerPrevY: 0,
+        pointerPrevTime: 0,
     };
 }
 
@@ -79,6 +91,9 @@ export function track(event: Event, x: number, y: number, time?: number): void {
             buffer.moveX = x;
             buffer.moveY = y;
             buffer.moveTime = time;
+            buffer.pointerPrevX = buffer.pointerX;
+            buffer.pointerPrevY = buffer.pointerY;
+            buffer.pointerPrevTime = buffer.pointerTime;
             buffer.pointerX = x;
             buffer.pointerY = y;
             buffer.pointerTime = time;
@@ -87,11 +102,28 @@ export function track(event: Event, x: number, y: number, time?: number): void {
             buffer.downX = x;
             buffer.downY = y;
             buffer.downTime = time;
+            buffer.pointerPrevX = buffer.pointerX;
+            buffer.pointerPrevY = buffer.pointerY;
+            buffer.pointerPrevTime = buffer.pointerTime;
+            buffer.pointerX = x;
+            buffer.pointerY = y;
+            buffer.pointerTime = time;
+            break;
+        case Event.MouseUp:
+            buffer.upX = x;
+            buffer.upY = y;
+            buffer.upTime = time;
+            buffer.pointerPrevX = buffer.pointerX;
+            buffer.pointerPrevY = buffer.pointerY;
+            buffer.pointerPrevTime = buffer.pointerTime;
             buffer.pointerX = x;
             buffer.pointerY = y;
             buffer.pointerTime = time;
             break;
         default:
+            buffer.pointerPrevX = buffer.pointerX;
+            buffer.pointerPrevY = buffer.pointerY;
+            buffer.pointerPrevTime = buffer.pointerTime;
             buffer.pointerX = x;
             buffer.pointerY = y;
             buffer.pointerTime = time;

--- a/packages/clarity-js/src/data/encode.ts
+++ b/packages/clarity-js/src/data/encode.ts
@@ -38,6 +38,12 @@ export default function(event: Event): void {
                 tokens.push(b.data.downX);
                 tokens.push(b.data.downY);
                 tokens.push(b.data.downTime);
+                tokens.push(b.data.upX);
+                tokens.push(b.data.upY);
+                tokens.push(b.data.upTime);
+                tokens.push(b.data.pointerPrevX);
+                tokens.push(b.data.pointerPrevY);
+                tokens.push(b.data.pointerPrevTime);
                 queue(tokens, false);
             }
             baseline.reset();

--- a/packages/clarity-js/types/data.d.ts
+++ b/packages/clarity-js/types/data.d.ts
@@ -433,6 +433,12 @@ export interface BaselineData {
     downX: number;
     downY: number;
     downTime: number;
+    upX: number;
+    upY: number;
+    upTime: number;
+    pointerPrevX: number;
+    pointerPrevY: number;
+    pointerPrevTime: number;
 }
 
 export interface IdentityData {


### PR DESCRIPTION
- adding support for tracking the previous pointer positions and times, as well as the coordinates and times of mouse up events.