### PR TITLE
Remove unused node param from TargetMetadata

### DIFF
--- a/packages/clarity-js/src/insight/snapshot.ts
+++ b/packages/clarity-js/src/insight/snapshot.ts
@@ -33,7 +33,7 @@ export function target(evt: UIEvent): Node {
 }
 
 export function metadata(node: Node): TargetMetadata {
-    let output: TargetMetadata = { id: 0, hash: null, privacy: config.conversions ? Privacy.Sensitive : Privacy.Snapshot, node };
+    let output: TargetMetadata = { id: 0, hash: null, privacy: config.conversions ? Privacy.Sensitive : Privacy.Snapshot };
     if (node) { output.id = idMap.has(node) ? idMap.get(node) : getId(node); }
     return output;
 }

--- a/packages/clarity-js/src/layout/target.ts
+++ b/packages/clarity-js/src/layout/target.ts
@@ -15,7 +15,7 @@ export function target(evt: UIEvent): Node {
 
 export function metadata(node: Node, event: Event, text: string = null): TargetMetadata {
     // If the node is null, we return a reserved value for id: 0. Valid assignment of id begins from 1+.
-    let output: TargetMetadata = { id: 0, hash: null, privacy: Privacy.Text, node };
+    let output: TargetMetadata = { id: 0, hash: null, privacy: Privacy.Text };
     if (node) {
         let value = dom.get(node);
         if (value !== null) {

--- a/packages/clarity-js/types/layout.d.ts
+++ b/packages/clarity-js/types/layout.d.ts
@@ -263,7 +263,6 @@ export interface TargetMetadata {
     id: number;
     hash: [string, string];
     privacy: Privacy;
-    node: Node;
 }
 
 export interface StyleSheetData {


### PR DESCRIPTION
Simplified metadata structure by eliminating unnecessary properties.