### PR TITLE
Address memory leak issue with event listeners

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.8.0",
+  "version": "0.8.1",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clarity",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "repository": "https://github.com/microsoft/clarity.git",
   "author": "Sarvesh Nagpal <sarveshn@microsoft.com>",
   "license": "MIT",

--- a/packages/clarity-decode/package.json
+++ b/packages/clarity-decode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-decode",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-js": "^0.8.0"
+    "clarity-js": "^0.8.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",

--- a/packages/clarity-devtools/package.json
+++ b/packages/clarity-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-devtools",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "description": "Adds Clarity debugging support to browser devtools",
   "author": "Microsoft Corp.",
@@ -24,9 +24,9 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.8.0",
-    "clarity-js": "^0.8.0",
-    "clarity-visualize": "^0.8.0"
+    "clarity-decode": "^0.8.1",
+    "clarity-js": "^0.8.1",
+    "clarity-visualize": "^0.8.1"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.0",

--- a/packages/clarity-devtools/static/manifest.json
+++ b/packages/clarity-devtools/static/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 2,
   "name": "Microsoft Clarity Developer Tools",
   "description": "Clarity helps you understand how users are interacting with your website.",
-  "version": "0.8.0",
-  "version_name": "0.8.0",
+  "version": "0.8.1",
+  "version_name": "0.8.1",
   "minimum_chrome_version": "50",
   "devtools_page": "devtools.html",
   "icons": {

--- a/packages/clarity-js/package.json
+++ b/packages/clarity-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/packages/clarity-js/src/core/version.ts
+++ b/packages/clarity-js/src/core/version.ts
@@ -1,2 +1,2 @@
-let version = "0.8.0";
+let version = "0.8.1";
 export default version;

--- a/packages/clarity-js/types/core.d.ts
+++ b/packages/clarity-js/types/core.d.ts
@@ -99,7 +99,6 @@ export interface OffsetDistance {
 
 export interface BrowserEvent {
     event: string;
-    target: EventTarget;
     listener: EventListener;
     options: {
         capture: boolean;

--- a/packages/clarity-visualize/package.json
+++ b/packages/clarity-visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-visualize",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.8.0"
+    "clarity-decode": "^0.8.1"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",


### PR DESCRIPTION
Currently, Clarity is not removing event listeners when observed nodes are removed. This leads to a memory leak issue as the event listeners are not properly cleaned up.
- Refactored event binding to use a `Map` for better management of event listeners and added a new `unbind` function to remove event listeners from specific targets.
- Replaced `observers` array with a `Set` in `mutation.ts` for better management of mutation observers. Added `disconnect` function to handle observer disconnections. 
- Added `iframeContentMap` in `dom.ts` to map iframe elements to their content documents and windows. Introduced `iframeContent`, `removeIFrame`, and `ignore` functions to manage iframe-related data and event listeners. 