### PR TITLE
Enhance event tracking logic and improve pointer state comparison

### DIFF
--- a/packages/clarity-js/src/interaction/encode.ts
+++ b/packages/clarity-js/src/interaction/encode.ts
@@ -40,12 +40,14 @@ export default async function (type: Event, ts: number = null): Promise<void> {
                     if (entry.data.id !== undefined) { 
                         tokens.push(entry.data.id); 
 
-                        if (entry.data.isPrimary !== undefined) { 
-                            tokens.push(entry.data.isPrimary.toString()); 
+                        if (entry.data.isPrimary !== undefined) {
+                            tokens.push(entry.data.isPrimary.toString());
                         }
                     }
                     queue(tokens);
-                    baseline.track(entry.event, entry.data.x, entry.data.y, entry.time);
+                    if (entry.data.isPrimary === undefined || entry.data.isPrimary) {
+                        baseline.track(entry.event, entry.data.x, entry.data.y, entry.time);
+                    }
                 }
             }
             pointer.reset();

--- a/packages/clarity-js/src/interaction/pointer.ts
+++ b/packages/clarity-js/src/interaction/pointer.ts
@@ -129,7 +129,8 @@ function similar(last: PointerState, current: PointerState): boolean {
     let distance = Math.sqrt(dx * dx + dy * dy);
     let gap = current.time - last.time;
     let match = current.data.target === last.data.target;
-    return current.event === last.event && match && distance < Setting.Distance && gap < Setting.Interval;
+    let sameId = current.data.id !== undefined ? current.data.id === last.data.id : true;
+    return current.event === last.event && match && distance < Setting.Distance && gap < Setting.Interval && sameId;
 }
 
 export function stop(): void {


### PR DESCRIPTION
- Only primary pointer (when available) events should update the baseline state. 
- Pointer “debouncing” should be pointer identifier aware.  