### PR TITLE
Stop collecting playback data after limit is reached in lean mode

### DIFF
--- a/packages/clarity-js/types/data.d.ts
+++ b/packages/clarity-js/types/data.d.ts
@@ -196,7 +196,8 @@ export const enum Code {
      */
     ContentSecurityPolicy = 7,
     Config = 8,
-    FunctionExecutionTime = 9
+    FunctionExecutionTime = 9,
+    LeanLimit = 10,
 }
 
 export const enum Severity {


### PR DESCRIPTION
In lean mode, Clarity keeps collecting playback data and keeps it in memory. When it reaches a limit, currently set at 10MB, it shuts down completely. Even `upgrade` signal is ignored afterwards. This changes the behavior to pause collecting playback data before the limit is reached so that other telemetry keeps getting sent and `upgrade` will still be supported.

_Limitation: mutations happening during the pause will be lost._