### PR TITLE
Add throttling for scroll, increase interval for similar events (0.8.11)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ debug.log
 
 # environment file
 .env
+
+# macOS metadata file
+.DS_Store

--- a/lerna.json
+++ b/lerna.json
@@ -2,7 +2,7 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.8.10",
+  "version": "0.8.11",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clarity",
   "private": true,
-  "version": "0.8.10",
+  "version": "0.8.11",
   "repository": "https://github.com/microsoft/clarity.git",
   "author": "Sarvesh Nagpal <sarveshn@microsoft.com>",
   "license": "MIT",

--- a/packages/clarity-decode/package.json
+++ b/packages/clarity-decode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-decode",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-js": "^0.8.10"
+    "clarity-js": "^0.8.11"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",

--- a/packages/clarity-devtools/package.json
+++ b/packages/clarity-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-devtools",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "private": true,
   "description": "Adds Clarity debugging support to browser devtools",
   "author": "Microsoft Corp.",
@@ -24,9 +24,9 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.8.10",
-    "clarity-js": "^0.8.10",
-    "clarity-visualize": "^0.8.10"
+    "clarity-decode": "^0.8.11",
+    "clarity-js": "^0.8.11",
+    "clarity-visualize": "^0.8.11"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.0",

--- a/packages/clarity-devtools/static/manifest.json
+++ b/packages/clarity-devtools/static/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 2,
   "name": "Microsoft Clarity Developer Tools",
   "description": "Clarity helps you understand how users are interacting with your website.",
-  "version": "0.8.10",
-  "version_name": "0.8.10",
+  "version": "0.8.11",
+  "version_name": "0.8.11",
   "minimum_chrome_version": "50",
   "devtools_page": "devtools.html",
   "icons": {

--- a/packages/clarity-js/package.json
+++ b/packages/clarity-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/packages/clarity-js/src/core/throttle.ts
+++ b/packages/clarity-js/src/core/throttle.ts
@@ -1,0 +1,35 @@
+/**
+ * Creates a throttled version of the provided function that only executes at most once
+ * every specified duration in milliseconds, ensuring the last event is not lost.
+ * @param func - The function to throttle.
+ * @param duration - The duration in milliseconds to wait before allowing the next execution.
+ * @returns A throttled version of the provided function.
+ */
+export default function throttle<T extends (...args: any[]) => void>(func: T, duration: number): T {
+  let lastExecutionTime = 0;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let lastArgs: Parameters<T> | null = null;
+
+  return function (...args: Parameters<T>) {
+    const now = performance.now();
+    const timeSinceLastExecution = now - lastExecutionTime;
+
+    // If the function is called during the throttling period, store the arguments to ensure we don't drop the last event
+    if (lastExecutionTime !== 0 && timeSinceLastExecution < duration) {
+      lastArgs = args;
+
+      if (timeoutId) return;
+
+      timeoutId = setTimeout(() => {
+        lastExecutionTime = performance.now();
+        func.apply(this, lastArgs!);
+        lastArgs = null;
+        timeoutId = null;
+      }, duration - timeSinceLastExecution);
+    } else {
+      // Execute immediately if outside the throttling period (including the first run)
+      lastExecutionTime = now;
+      func.apply(this, args);
+    }
+  } as T;
+}

--- a/packages/clarity-js/src/core/version.ts
+++ b/packages/clarity-js/src/core/version.ts
@@ -1,2 +1,2 @@
-const version = "0.8.10";
+const version = "0.8.11";
 export default version;

--- a/packages/clarity-js/src/interaction/pointer.ts
+++ b/packages/clarity-js/src/interaction/pointer.ts
@@ -139,7 +139,7 @@ function similar(last: PointerState, current: PointerState): boolean {
     const gap = current.time - last.time;
     const match = current.data.target === last.data.target;
     const sameId = current.data.id !== undefined ? current.data.id === last.data.id : true;
-    return current.event === last.event && match && distance < Setting.Distance && gap < Setting.Interval && sameId;
+    return current.event === last.event && match && distance < Setting.Distance && gap < Setting.PointerInterval && sameId;
 }
 
 export function stop(): void {

--- a/packages/clarity-js/src/interaction/scroll.ts
+++ b/packages/clarity-js/src/interaction/scroll.ts
@@ -5,6 +5,7 @@ import { bind } from "@src/core/event";
 import { schedule } from "@src/core/task";
 import { time } from "@src/core/time";
 import { clearTimeout, setTimeout } from "@src/core/timeout";
+import throttle from "@src/core/throttle";
 import * as dimension from "@src/data/dimension";
 import { iframe } from "@src/layout/dom";
 import { metadata, target } from "@src/layout/target";
@@ -23,7 +24,7 @@ export function start(): void {
 export function observe(root: Node): void {
     const frame = iframe(root);
     const node = frame ? frame.contentWindow : root === document ? window : root;
-    bind(node, "scroll", recompute, true);
+    bind(node, "scroll", throttledRecompute, true);
 }
 
 function recompute(event: UIEvent = null): void {
@@ -73,6 +74,8 @@ function recompute(event: UIEvent = null): void {
     timeout = setTimeout(process, Setting.LookAhead, Event.Scroll);
 }
 
+const throttledRecompute = throttle(recompute, Setting.Throttle);
+
 function getPositionNode(x: number, y: number): Node {
     let node: Node;
     if ("caretPositionFromPoint" in document) {
@@ -104,7 +107,7 @@ function process(event: Event): void {
 function similar(last: ScrollState, current: ScrollState): boolean {
     const dx = last.data.x - current.data.x;
     const dy = last.data.y - current.data.y;
-    return dx * dx + dy * dy < Setting.Distance * Setting.Distance && current.time - last.time < Setting.Interval;
+    return dx * dx + dy * dy < Setting.Distance * Setting.Distance && current.time - last.time < Setting.ScrollInterval;
 }
 
 export function compute(): void {

--- a/packages/clarity-js/types/interaction.d.ts
+++ b/packages/clarity-js/types/interaction.d.ts
@@ -15,7 +15,9 @@ export const enum Setting {
     LookAhead = 500, // 500ms
     InputLookAhead = 1000, // 1s
     Distance = 20, // 20 pixels
-    Interval = 25, // 25 milliseconds
+    ScrollInterval = 50, // 25 milliseconds
+    PointerInterval = 25, // 25 milliseconds
+    Throttle = 25, // 25 milliseconds
     // biome-ignore lint/style/useLiteralEnumMembers: Time.Second is a const enum, it is compiled to a number
     TimelineSpan = 2 * Time.Second, // 2 seconds
 }

--- a/packages/clarity-visualize/package.json
+++ b/packages/clarity-visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-visualize",
-  "version": "0.8.10",
+  "version": "0.8.11",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.8.10"
+    "clarity-decode": "^0.8.11"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",


### PR DESCRIPTION
This pull request introduces a throttling mechanism to improve the performance of scroll event handling in the `clarity-js` package. The most important changes include the addition of a reusable `throttle` utility function, its integration into the scroll event observer, and the replacement of the unthrottled `recompute` function with a throttled version.