### PR TITLE
viewport null check

### DIFF
--- a/packages/clarity-js/src/layout/region.ts
+++ b/packages/clarity-js/src/layout/region.ts
@@ -102,7 +102,7 @@ function handler(entries: IntersectionObserverEntry[]): void {
         // that cannot ever be seen by the user. In some cases, websites will have a multiple copy of the same region
         // like search box - one for desktop, and another for mobile. In those cases, CSS media queries determine which one should be visible.
         // Also, if these regions ever become non-zero width or height (through AJAX, user action or orientation change) - we will automatically start monitoring them from that point onwards
-        if (regionMap.has(target) && rect.width + rect.height > 0 && viewport.width > 0 && viewport.height > 0) {
+        if (regionMap.has(target) && rect.width + rect.height > 0 && viewport && viewport.width > 0 && viewport.height > 0) {
             const id = target ? dom.getId(target) : null;
             const data =
                 id in regions


### PR DESCRIPTION
the `rootBounds` of `IntersectionObserverEntry` is possible to be `null` (ref: https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserverEntry/rootBounds), so we need to check if it's `null` before using it

I've already seen a lot of such errors around, so I think it's a good idea to add the check here.