### PR TITLE
Added throttling and increased interval for similar scroll events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ debug.log
 
 # environment file
 .env
+
+# macOS metadata file
+.DS_Store

--- a/packages/clarity-js/src/core/throttle.ts
+++ b/packages/clarity-js/src/core/throttle.ts
@@ -1,0 +1,35 @@
+/**
+ * Creates a throttled version of the provided function that only executes at most once
+ * every specified duration in milliseconds, ensuring the last event is not lost.
+ * @param func - The function to throttle.
+ * @param duration - The duration in milliseconds to wait before allowing the next execution.
+ * @returns A throttled version of the provided function.
+ */
+export default function throttle<T extends (...args: any[]) => void>(func: T, duration: number): T {
+  let lastExecutionTime = 0;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+  let lastArgs: Parameters<T> | null = null;
+
+  return function (...args: Parameters<T>) {
+    const now = performance.now();
+    const timeSinceLastExecution = now - lastExecutionTime;
+
+    // If the function is called during the throttling period, store the arguments to ensure we don't drop the last event
+    if (lastExecutionTime !== 0 && timeSinceLastExecution < duration) {
+      lastArgs = args;
+
+      if (timeoutId) return;
+
+      timeoutId = setTimeout(() => {
+        lastExecutionTime = performance.now();
+        func.apply(this, lastArgs!);
+        lastArgs = null;
+        timeoutId = null;
+      }, duration - timeSinceLastExecution);
+    } else {
+      // Execute immediately if outside the throttling period (including the first run)
+      lastExecutionTime = now;
+      func.apply(this, args);
+    }
+  } as T;
+}

--- a/packages/clarity-js/src/interaction/pointer.ts
+++ b/packages/clarity-js/src/interaction/pointer.ts
@@ -130,7 +130,7 @@ function similar(last: PointerState, current: PointerState): boolean {
     let gap = current.time - last.time;
     let match = current.data.target === last.data.target;
     let sameId = current.data.id !== undefined ? current.data.id === last.data.id : true;
-    return current.event === last.event && match && distance < Setting.Distance && gap < Setting.Interval && sameId;
+    return current.event === last.event && match && distance < Setting.Distance && gap < Setting.PointerInterval && sameId;
 }
 
 export function stop(): void {

--- a/packages/clarity-js/src/interaction/scroll.ts
+++ b/packages/clarity-js/src/interaction/scroll.ts
@@ -5,6 +5,7 @@ import { bind } from "@src/core/event";
 import { schedule } from "@src/core/task";
 import { time } from "@src/core/time";
 import { clearTimeout, setTimeout } from "@src/core/timeout";
+import throttle from "@src/core/throttle";
 import { iframe } from "@src/layout/dom";
 import { target, metadata } from "@src/layout/target";
 import encode from "./encode";
@@ -23,7 +24,7 @@ export function start(): void {
 export function observe(root: Node): void {
     let frame = iframe(root);
     let node = frame ? frame.contentWindow : (root === document ? window : root);
-    bind(node, "scroll", recompute, true);
+    bind(node, "scroll", throttledRecompute, true);
 }
 
 function recompute(event: UIEvent = null): void {
@@ -71,6 +72,8 @@ function recompute(event: UIEvent = null): void {
     timeout = setTimeout(process, Setting.LookAhead, Event.Scroll);
 }
 
+const throttledRecompute = throttle(recompute, Setting.Throttle);
+
 function getPositionNode(x: number, y: number): Node {
     let node: Node;
     if ("caretPositionFromPoint" in document) {
@@ -101,7 +104,7 @@ function process(event: Event): void {
 function similar(last: ScrollState, current: ScrollState): boolean {
     let dx = last.data.x - current.data.x;
     let dy = last.data.y - current.data.y;
-    return (dx * dx + dy * dy < Setting.Distance * Setting.Distance) && (current.time - last.time < Setting.Interval);
+    return (dx * dx + dy * dy < Setting.Distance * Setting.Distance) && (current.time - last.time < Setting.ScrollInterval);
 }
 
 export function compute(): void {

--- a/packages/clarity-js/types/interaction.d.ts
+++ b/packages/clarity-js/types/interaction.d.ts
@@ -15,7 +15,9 @@ export const enum Setting {
     LookAhead = 500, // 500ms
     InputLookAhead = 1000, // 1s
     Distance = 20, // 20 pixels
-    Interval = 25, // 25 milliseconds
+    ScrollInterval = 50, // 25 milliseconds
+    PointerInterval = 25, // 25 milliseconds
+    Throttle = 25, // 25 milliseconds
     TimelineSpan = 2 * Time.Second, // 2 seconds
 }
 


### PR DESCRIPTION
This pull request introduces a throttling mechanism to improve the performance of scroll event handling in the clarity-js package. The most important changes include the addition of a reusable throttle utility function, its integration into the scroll event observer, and the replacement of the unthrottled recompute function with a throttled version.

Original PR: https://github.com/microsoft/clarity/pull/827