### PR TITLE
null check for envelope data

### DIFF
--- a/packages/clarity-js/src/core/report.ts
+++ b/packages/clarity-js/src/core/report.ts
@@ -12,7 +12,7 @@ export function report(e: Error): Error {
     // Do not report the same message twice for the same page
     if (history && history.indexOf(e.message) === -1) {
         const url = config.report;
-        if (url && url.length > 0) {
+        if (url && url.length > 0 && data) {
             let payload: Report = {v: data.version, p: data.projectId, u: data.userId, s: data.sessionId, n: data.pageNum};
             if (e.message) { payload.m = e.message; }
             if (e.stack) { payload.e = e.stack; }


### PR DESCRIPTION
The data defaults to null, and since strictNullChecks is not enabled in tsconfig, assigning null to data is considered valid.

We've encountered related errors in our project, so I'm submitting this small PR to help prevent such issues.

Original PR: https://github.com/microsoft/clarity/pull/850