### PR TITLE
Support for node v23

### DIFF
--- a/packages/clarity-decode/rollup.config.ts
+++ b/packages/clarity-decode/rollup.config.ts
@@ -2,7 +2,9 @@ import commonjs from "@rollup/plugin-commonjs";
 import resolve from "@rollup/plugin-node-resolve";
 import terser from "@rollup/plugin-terser";
 import typescript from "@rollup/plugin-typescript";
-import pkg from "./package.json" assert { type: 'json' };
+import { readFileSync } from "fs";
+
+const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
 
 export default [
   {

--- a/packages/clarity-js/rollup.config.ts
+++ b/packages/clarity-js/rollup.config.ts
@@ -1,9 +1,11 @@
 import alias from "@rollup/plugin-alias";
 import commonjs from "@rollup/plugin-commonjs";
-import resolve from "@rollup/plugin-node-resolve";  
+import resolve from "@rollup/plugin-node-resolve";
 import terser from "@rollup/plugin-terser";
 import typescript from "@rollup/plugin-typescript";
-import pkg from "./package.json" assert { type: 'json' };
+import { readFileSync } from "fs";
+
+const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
 export default [
   {
     input: "src/index.ts",
@@ -28,7 +30,7 @@ export default [
       if (message.code === 'CIRCULAR_DEPENDENCY') { return; }
       warn(message);
     },
-    plugins: [,
+    plugins: [
       resolve(),
       typescript(),
       terser({output: {comments: false}}),

--- a/packages/clarity-js/src/layout/style.ts
+++ b/packages/clarity-js/src/layout/style.ts
@@ -1,4 +1,4 @@
-import { Event, Metric } from "@clarity-types/data";
+import { Event } from "@clarity-types/data";
 import { StyleSheetOperation, StyleSheetState } from "@clarity-types/layout";
 import { time } from "@src/core/time";
 import { shortid } from "@src/data/metadata";

--- a/packages/clarity-visualize/rollup.config.ts
+++ b/packages/clarity-visualize/rollup.config.ts
@@ -3,7 +3,9 @@ import resolve from "@rollup/plugin-node-resolve";
 import terser from "@rollup/plugin-terser";
 import typescript from "@rollup/plugin-typescript";
 import { importAsString } from 'rollup-plugin-string-import';
-import pkg from "./package.json" assert { type: 'json' };
+import { readFileSync } from "fs";
+
+const pkg = JSON.parse(readFileSync("./package.json", "utf-8"));
 
 function wrapWithBackground(svg){
   return `background: url("data:image/svg+xml,${svg}") no-repeat center center;`;


### PR DESCRIPTION
This pull request updates the handling of `package.json` imports in Rollup configuration files, fixes a plugin array issue in `clarity-js`, and removes an unused import in `clarity-js` source code. 

Replaced the `assert { type: 'json' }` syntax for importing `package.json` with `fs.readFileSync` and `JSON.parse` in `rollup.config.ts`. This ensures compatibility with newer NodeJS versions that dropped support for `assert` syntax.