### PR TITLE
feat: Enhance Clarity click tracking with aria-label fallback

### DIFF
--- a/packages/clarity-js/types/interaction.d.ts
+++ b/packages/clarity-js/types/interaction.d.ts
@@ -125,7 +125,6 @@ export interface ClickData {
     hash: string;
     trust: number;
     isFullText: BooleanFlag;
-    ariaLabel?: string | null;
 }
 
 export interface TextInfo {


### PR DESCRIPTION
Previously, Clarity's `text` extraction logic primarily relied on `textContent`, `value`, or `alt` attributes. This could lead to "blank click" observations in recordings when users interacted with elements, like icon-only buttons, that convey their meaning primarily through the `aria-label` attribute rather than visible text.
