### PR TITLE
Move animation event to playback property in payload

### DIFF
--- a/packages/clarity-js/src/clarity.ts
+++ b/packages/clarity-js/src/clarity.ts
@@ -15,6 +15,7 @@ export { version };
 export { consent, consentv2, event, identify, set, upgrade, metadata, signal, maxMetric } from "@src/data";
 export { queue } from "@src/data/upload";
 export { register } from "@src/core/dynamic";
+export { schedule } from "@src/core/task";
 export { time } from "@src/core/time";
 export { hashText } from "@src/layout";
 export { measure };

--- a/packages/clarity-js/src/data/upload.ts
+++ b/packages/clarity-js/src/data/upload.ts
@@ -71,6 +71,7 @@ export function queue(tokens: Token[], transmit: boolean = true): void {
         case Event.Snapshot:
         case Event.StyleSheetAdoption:
         case Event.StyleSheetUpdate:
+        case Event.Animation:
             if (leanLimit) { break; }
             playbackBytes += event.length;
             playback.push(event);


### PR DESCRIPTION
- Expose `task.schedule` for use in dynamic modules