### PR TITLE
Expand web components support to heatmaps

### DIFF
--- a/packages/clarity-visualize/src/layout.ts
+++ b/packages/clarity-visualize/src/layout.ts
@@ -245,7 +245,9 @@ export class LayoutHelper {
     }
 
     public customElement = (event: DecodedLayout.CustomElementEvent): void => {
-        this.state.window.customElements.define(event.data.name, class extends (this.state.window as typeof window).HTMLElement {});
+        if (!this.state.window.customElements.get(event.data.name)) {
+            this.state.window.customElements.define(event.data.name, class extends (this.state.window as typeof window).HTMLElement {});
+        }
     }
 
     private setDocumentStyles(documentId: number, styleIds: string[]) {

--- a/packages/clarity-visualize/src/visualizer.ts
+++ b/packages/clarity-visualize/src/visualizer.ts
@@ -67,6 +67,9 @@ export class Visualizer implements VisualizerType {
                         case Data.Event.StyleSheetUpdate:
                             this.layout.styleChange(entry as Layout.StyleSheetEvent);
                             break;
+                        case Data.Event.CustomElement:
+                            this.layout.customElement(entry as Layout.CustomElementEvent);
+                            break;
                         case Data.Event.Mutation:
                             let domEvent = entry as Layout.DomEvent;
                             this.renderTime = domEvent.time;


### PR DESCRIPTION
Expanding support for web components to heatmaps by adding them in the `html(...)` path of the visualizer.