### PR TITLE
Handling missing events

### DIFF
--- a/packages/clarity-decode/src/clarity.ts
+++ b/packages/clarity-decode/src/clarity.ts
@@ -3,7 +3,7 @@ import { BaselineEvent, CustomEvent, DecodedPayload, DecodedVersion, DimensionEv
 import { LimitEvent, MetricEvent, PingEvent, SummaryEvent, UpgradeEvent, UploadEvent, VariableEvent, ExtractEvent, ConsentEvent } from "../types/data";
 import { FraudEvent, LogEvent, ScriptErrorEvent } from "../types/diagnostic";
 import { ChangeEvent, ClickEvent, ContextMenuEvent, ClipboardEvent, InputEvent, PointerEvent, ResizeEvent, ScrollEvent } from "../types/interaction";
-import { SelectionEvent, SubmitEvent, TimelineEvent, UnloadEvent, VisibilityEvent } from "../types/interaction";
+import { SelectionEvent, SubmitEvent, TimelineEvent, UnloadEvent, VisibilityEvent, FocusEvent } from "../types/interaction";
 import { CustomElementEvent, DocumentEvent, DomEvent, RegionEvent } from "../types/layout";
 import { NavigationEvent } from "../types/performance";
 
@@ -148,6 +148,10 @@ export function decode(input: string): DecodedPayload {
             case Data.Event.Visibility:
                 if (payload.visibility === undefined) { payload.visibility = []; }
                 payload.visibility.push(interaction.decode(entry) as VisibilityEvent);
+                break;
+            case Data.Event.Focus:
+                if (payload.focus === undefined) { payload.focus = []; }
+                payload.focus.push(interaction.decode(entry) as FocusEvent);
                 break;
             case Data.Event.Box:
                 /* Deprecated - Intentionally, no-op. For backward compatibility. */

--- a/packages/clarity-decode/types/data.d.ts
+++ b/packages/clarity-decode/types/data.d.ts
@@ -1,7 +1,7 @@
 import { Data } from "clarity-js";
 import { DiagnosticEvent, FraudEvent, LogEvent, ScriptErrorEvent } from "./diagnostic";
 import { ChangeEvent, ClickEvent, ContextMenuEvent, ClipboardEvent, InputEvent, InteractionEvent, PointerEvent, ResizeEvent, SubmitEvent } from "./interaction";
-import { ScrollEvent, SelectionEvent, TimelineEvent, UnloadEvent, VisibilityEvent } from "./interaction";
+import { ScrollEvent, SelectionEvent, TimelineEvent, UnloadEvent, VisibilityEvent, FocusEvent } from "./interaction";
 import { DocumentEvent, DomEvent, LayoutEvent, RegionEvent, CustomElementEvent } from "./layout";
 import { NavigationEvent, PerformanceEvent } from "./performance";
 import { PartialEvent } from "./core";
@@ -71,6 +71,7 @@ export interface DecodedPayload {
     upgrade?: UpgradeEvent[];
     upload?: UploadEvent[];
     visibility?: VisibilityEvent[];
+    focus?: FocusEvent[];
     region?: RegionEvent[];
     dom?: DomEvent[];
     doc?: DocumentEvent[];

--- a/packages/clarity-decode/types/interaction.d.ts
+++ b/packages/clarity-decode/types/interaction.d.ts
@@ -28,6 +28,7 @@ export interface SubmitEvent extends PartialEvent { data: Interaction.SubmitData
 export interface TimelineEvent extends PartialEvent { data: TimelineData; }
 export interface UnloadEvent extends PartialEvent { data: Interaction.UnloadData; }
 export interface VisibilityEvent extends PartialEvent { data: Interaction.VisibilityData; }
+export interface FocusEvent extends PartialEvent { data: Interaction.FocusData; }
 export interface InteractionEvent extends PartialEvent {
     data: ClickData |
     Interaction.ChangeData |


### PR DESCRIPTION
Handling focus and internal events in `clarity-decode`