### PR TITLE
Add width and height properties to click event metadata

### DIFF
--- a/packages/clarity-decode/src/interaction.ts
+++ b/packages/clarity-decode/src/interaction.ts
@@ -39,6 +39,8 @@ export function decode(tokens: Data.Token[]): InteractionEvent {
                 hashBeta: clickHashes.length > 0 ? clickHashes[1] : null,
                 trust: tokens.length > 13 ? tokens[13] as number : Data.BooleanFlag.True,
                 isFullText: tokens.length > 14 ? tokens[14] as number : null,
+                w: tokens.length > 15 ? tokens[15] as number : 0,
+                h: tokens.length > 16 ? tokens[16] as number : 0
             };
             return { time, event, data: clickData };
         case Data.Event.Clipboard:

--- a/packages/clarity-js/src/interaction/click.ts
+++ b/packages/clarity-js/src/interaction/click.ts
@@ -70,6 +70,8 @@ function handler(event: Event, root: Node, evt: MouseEvent): void {
                 hash: null,
                 trust: evt.isTrusted ? BooleanFlag.True : BooleanFlag.False,
                 isFullText: textInfo.isFullText,
+                w: l ? l.w : 0,
+                h: l ? l.h : 0
             }
         });
         schedule(encode.bind(this, event));

--- a/packages/clarity-js/src/interaction/encode.ts
+++ b/packages/clarity-js/src/interaction/encode.ts
@@ -72,6 +72,8 @@ export default async function (type: Event, ts: number = null): Promise<void> {
                 tokens.push(cHash);
                 tokens.push(entry.data.trust);
                 tokens.push(entry.data.isFullText);
+                tokens.push(entry.data.w);
+                tokens.push(entry.data.h);
                 queue(tokens);
                 timeline.track(entry.time, entry.event, cHash, entry.data.x, entry.data.y, entry.data.reaction, entry.data.context);
             }

--- a/packages/clarity-js/types/interaction.d.ts
+++ b/packages/clarity-js/types/interaction.d.ts
@@ -126,6 +126,8 @@ export interface ClickData {
     hash: string;
     trust: number;
     isFullText: BooleanFlag;
+    w: number;
+    h: number;
 }
 
 export interface TextInfo {


### PR DESCRIPTION
This pull request adds support for capturing and encoding the width (`w`) and height (`h`) properties of click interactions.