### PR TITLE
Fix(interaction): handle null targets in scroll/click to prevent Type Error #852

### DIFF
--- a/packages/clarity-js/src/interaction/click.ts
+++ b/packages/clarity-js/src/interaction/click.ts
@@ -24,8 +24,8 @@ export function observe(root: Node): void {
 function handler(event: Event, root: Node, evt: MouseEvent): void {
     let frame = iframe(root);
     let d = frame && frame.contentDocument ? frame.contentDocument.documentElement : document.documentElement;
-    let x = "pageX" in evt ? Math.round(evt.pageX) : ("clientX" in evt ? Math.round(evt["clientX"] + d.scrollLeft) : null);
-    let y = "pageY" in evt ? Math.round(evt.pageY) : ("clientY" in evt ? Math.round(evt["clientY"] + d.scrollTop) : null);
+    let x = "pageX" in evt ? Math.round(evt.pageX) : ("clientX" in evt ? Math.round(evt["clientX"] + (d?.scrollLeft || 0)) : null);
+    let y = "pageY" in evt ? Math.round(evt.pageY) : ("clientY" in evt ? Math.round(evt["clientY"] + (d?.scrollTop || 0)) : null);
     // In case of iframe, we adjust (x,y) to be relative to top parent's origin
     if (frame) {
         let distance = offset(frame);

--- a/packages/clarity-js/src/interaction/pointer.ts
+++ b/packages/clarity-js/src/interaction/pointer.ts
@@ -34,8 +34,8 @@ export function observe(root: Node): void {
 function mouse(event: Event, root: Node, evt: MouseEvent): void {
     let frame = iframe(root);
     let d = frame && frame.contentDocument ? frame.contentDocument.documentElement : document.documentElement;
-    let x = "pageX" in evt ? Math.round(evt.pageX) : ("clientX" in evt ? Math.round(evt["clientX"] + d.scrollLeft) : null);
-    let y = "pageY" in evt ? Math.round(evt.pageY) : ("clientY" in evt ? Math.round(evt["clientY"] + d.scrollTop) : null);
+    let x = "pageX" in evt ? Math.round(evt.pageX) : ("clientX" in evt ? Math.round(evt["clientX"] + (d?.scrollLeft || 0)) : null);
+    let y = "pageY" in evt ? Math.round(evt.pageY) : ("clientY" in evt ? Math.round(evt["clientY"] + (d?.scrollTop || 0)) : null);
     // In case of iframe, we adjust (x,y) to be relative to top parent's origin
     if (frame) {
         let distance = offset(frame);
@@ -56,8 +56,8 @@ function touch(event: Event, root: Node, evt: TouchEvent): void {
     if (touches) {
         for (let i = 0; i < touches.length; i++) {
             let entry = touches[i];
-            let x = "clientX" in entry ? Math.round(entry["clientX"] + d.scrollLeft) : null;
-            let y = "clientY" in entry ? Math.round(entry["clientY"] + d.scrollTop) : null;
+            let x = "clientX" in entry ? Math.round(entry["clientX"] + (d?.scrollLeft || 0)) : null;
+            let y = "clientY" in entry ? Math.round(entry["clientY"] + (d?.scrollTop || 0)) : null;
             x = x && frame ? x + Math.round(frame.offsetLeft) : x;
             y = y && frame ? y + Math.round(frame.offsetTop) : y;
 

--- a/packages/clarity-js/src/interaction/scroll.ts
+++ b/packages/clarity-js/src/interaction/scroll.ts
@@ -45,8 +45,8 @@ function recompute(event: UIEvent = null): void {
     // Edge doesn't support scrollTop position on document.documentElement.
     // For cross browser compatibility, looking up pageYOffset on window if the scroll is on document.
     // And, if for some reason that is not available, fall back to looking up scrollTop on document.documentElement.
-    let x = element === de && "pageXOffset" in w ? Math.round(w.pageXOffset) : Math.round((element as HTMLElement).scrollLeft);
-    let y = element === de && "pageYOffset" in w ? Math.round(w.pageYOffset) : Math.round((element as HTMLElement).scrollTop);
+    let x = element === de && "pageXOffset" in w ? Math.round(w.pageXOffset) : Math.round((element as HTMLElement)?.scrollLeft ?? 0);
+    let y = element === de && "pageYOffset" in w ? Math.round(w.pageYOffset) : Math.round((element as HTMLElement)?.scrollTop ?? 0);
     const width = window.innerWidth;
     const height = window.innerHeight;
     const xPosition = width / 3;


### PR DESCRIPTION
### Description
This PR fixes a `TypeError` reported in issue #852 ("Cannot read properties of null (reading 'scrollLeft')"). 

This error occurs when `scrollLeft` or `scrollTop` is accessed on a `null` element, which can happen in certain edge cases (e.g., inside React/Next.js applications where elements might be detached or managing shadow DOM).

### Changes
I added optional chaining (`?.`) and a fallback (`|| 0`) to handle null targets safely in:
- `packages/clarity-js/src/interaction/scroll.ts`
- `packages/clarity-js/src/interaction/click.ts`
- `packages/clarity-js/src/interaction/pointer.ts`

### Verification
- Ran `npm run build` successfully.
- Verified that the changes introduce null-checks without altering the logic for valid elements.

Fixes #852

cc @AbdelrhmanMagdy (Since you looked into this previously, I thought you might want to review this fix).