### PR TITLE
Add trackEmbedded config option for cross-origin iframe cookie support

### DIFF
--- a/packages/clarity-js/src/core/config.ts
+++ b/packages/clarity-js/src/core/config.ts
@@ -24,6 +24,7 @@ let config: Config = {
     throttleDom: true,
     conversions: false,
     includeSubdomains: true,
+    trackEmbedded: false,
     modules: [],
     diagnostics: false,
 };

--- a/packages/clarity-js/src/data/cookie.ts
+++ b/packages/clarity-js/src/data/cookie.ts
@@ -56,7 +56,8 @@ export function setCookie(key: string, value: string, time: number): void {
     let expiry = new Date();
     expiry.setDate(expiry.getDate() + time);
     let expires = expiry ? Constant.Expires + expiry.toUTCString() : Constant.Empty;
-    let cookie = `${key}=${encodedValue}${Constant.Semicolon}${expires}${Constant.Path}`;
+    let sameSite = config.trackEmbedded ? `${Constant.Semicolon}SameSite=None${Constant.Semicolon}Secure` : Constant.Empty;
+    let cookie = `${key}=${encodedValue}${Constant.Semicolon}${expires}${Constant.Path}${sameSite}`;
     try {
       // Attempt to get the root domain only once and fall back to writing cookie on the current domain.
       if (rootDomain === null) {

--- a/packages/clarity-js/test/cookie.test.ts
+++ b/packages/clarity-js/test/cookie.test.ts
@@ -1,0 +1,123 @@
+import { expect, test } from "@playwright/test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Cookie attribute tests - Verifies that document.cookie assignments include the correct
+ * attributes based on the trackEmbedded config option. Tests load the built clarity.min.js
+ * in a browser context and intercept raw cookie assignments to inspect their attributes.
+ */
+
+// Maximum time to wait for Clarity to write cookies after start
+const COOKIE_WRITE_TIMEOUT = 2000;
+
+const clarityJsPath = join(__dirname, "../build/clarity.min.js");
+
+/**
+ * Sets up a cookie mock that both stores cookies (so reads work) and records
+ * the raw assignment strings so tests can inspect attributes like SameSite and Secure.
+ */
+function setupCookieCaptureMock(): void {
+    let cookieStore = "";
+    const rawAssignments: string[] = [];
+    (window as any).__cookieAssignments = rawAssignments;
+
+    Object.defineProperty(document, "cookie", {
+        get: (): string => cookieStore,
+        set: (value: string): void => {
+            rawAssignments.push(value);
+            // Handle cookie deletion (max-age=- or empty value patterns)
+            if (value.includes("max-age=-") || value.includes("=;") || value.includes("=^;")) {
+                const cookieName = value.split("=")[0];
+                const cookies = cookieStore.split("; ").filter((c: string) => !c.startsWith(cookieName + "="));
+                cookieStore = cookies.join("; ");
+            } else {
+                // Store only the name=value portion (strip attributes) so subsequent reads work
+                const cookieName = value.split("=")[0];
+                const cookies = cookieStore.split("; ").filter((c: string) => !c.startsWith(cookieName + "="));
+                cookies.push(value.split(";")[0]);
+                cookieStore = cookies.filter((c: string) => c).join("; ");
+            }
+        },
+        configurable: true,
+    });
+}
+
+test.describe("Cookie - trackEmbedded config", () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto("data:text/html,<!DOCTYPE html><html><head></head><body></body></html>");
+        const clarityJs = readFileSync(clarityJsPath, "utf-8");
+        await page.evaluate((code: string) => {
+            eval(code);
+        }, clarityJs);
+    });
+
+    test("trackEmbedded=false (default): cookies are set without SameSite=None or Secure", async ({ page }) => {
+        await page.evaluate(setupCookieCaptureMock as () => void);
+
+        await page.evaluate(({ timeout }) => {
+            return new Promise<void>((resolve) => {
+                (window as any).clarity("start", {
+                    projectId: "test",
+                    track: true,
+                    upload: false,
+                    // trackEmbedded not set — defaults to false
+                });
+
+                // Wait for cookies to be written via consent callback
+                (window as any).clarity("metadata", (_data: any, _upgrade: any, consent: any) => {
+                    if (consent) { resolve(); }
+                }, false, true, true);
+
+                setTimeout(resolve, timeout);
+            });
+        }, { timeout: COOKIE_WRITE_TIMEOUT });
+
+        const rawAssignments = await page.evaluate((): string[] => (window as any).__cookieAssignments);
+
+        // At least one cookie must have been written
+        expect(rawAssignments.length).toBeGreaterThan(0);
+
+        // None of the assignments should carry SameSite=None or Secure
+        const withSameSite = rawAssignments.filter((a: string) => /samesite=none/i.test(a));
+        const withSecure = rawAssignments.filter((a: string) => /;\s*secure\b/i.test(a));
+        expect(withSameSite).toHaveLength(0);
+        expect(withSecure).toHaveLength(0);
+    });
+
+    test("trackEmbedded=true: cookies are set with SameSite=None and Secure", async ({ page }) => {
+        await page.evaluate(setupCookieCaptureMock as () => void);
+
+        await page.evaluate(({ timeout }) => {
+            return new Promise<void>((resolve) => {
+                (window as any).clarity("start", {
+                    projectId: "test",
+                    track: true,
+                    trackEmbedded: true,
+                    upload: false,
+                });
+
+                (window as any).clarity("metadata", (_data: any, _upgrade: any, consent: any) => {
+                    if (consent) { resolve(); }
+                }, false, true, true);
+
+                setTimeout(resolve, timeout);
+            });
+        }, { timeout: COOKIE_WRITE_TIMEOUT });
+
+        const rawAssignments = await page.evaluate((): string[] => (window as any).__cookieAssignments);
+
+        expect(rawAssignments.length).toBeGreaterThan(0);
+
+        // Every non-deletion cookie assignment must carry SameSite=None and Secure
+        const cookieWrites = rawAssignments.filter((a: string) =>
+            !a.includes("max-age=-") && !a.includes("=;") && !a.includes("=^;")
+        );
+        expect(cookieWrites.length).toBeGreaterThan(0);
+
+        cookieWrites.forEach((assignment: string) => {
+            expect(assignment).toMatch(/samesite=none/i);
+            expect(assignment).toMatch(/;\s*secure\b/i);
+        });
+    });
+});

--- a/packages/clarity-js/types/core.d.ts
+++ b/packages/clarity-js/types/core.d.ts
@@ -140,6 +140,7 @@ export interface Config {
     throttleDom?: boolean;
     conversions?: boolean;
     includeSubdomains?: boolean;
+    trackEmbedded?: boolean;
     modules?: string[];
     diagnostics?: boolean;
 }


### PR DESCRIPTION
## Summary
- Adds `trackEmbedded` boolean config option (default: `false`) to enable session tracking in cross-origin iframe contexts
- When `true`, cookies are written with `SameSite=None; Secure` attributes, which browsers require for cross-origin cookie access
- Adds Playwright tests verifying cookie attributes are present/absent based on the config value

## Test plan
- [x] `trackEmbedded=false` (default): verify no `SameSite=None` or `Secure` attributes on cookie assignments
- [x] `trackEmbedded=true`: verify all cookie assignments include both `SameSite=None` and `Secure`
- [x] All 29 existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)