### PR TITLE
Rotate buffers before serialization to prevent data loss during uploads (0.8.64)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.8.63",
+  "version": "0.8.64",
   "npmClient": "yarn"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clarity",
   "private": true,
-  "version": "0.8.63",
+  "version": "0.8.64",
   "repository": "https://github.com/microsoft/clarity.git",
   "author": "Sarvesh Nagpal <sarveshn@microsoft.com>",
   "license": "MIT",

--- a/packages/clarity-decode/package.json
+++ b/packages/clarity-decode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-decode",
-  "version": "0.8.63",
+  "version": "0.8.64",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-js": "^0.8.63"
+    "clarity-js": "^0.8.64"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",

--- a/packages/clarity-devtools/package.json
+++ b/packages/clarity-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-devtools",
-  "version": "0.8.63",
+  "version": "0.8.64",
   "private": true,
   "description": "Adds Clarity debugging support to browser devtools",
   "author": "Microsoft Corp.",
@@ -24,9 +24,9 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.8.63",
-    "clarity-js": "^0.8.63",
-    "clarity-visualize": "^0.8.63"
+    "clarity-decode": "^0.8.64",
+    "clarity-js": "^0.8.64",
+    "clarity-visualize": "^0.8.64"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.0",

--- a/packages/clarity-devtools/static/manifest.json
+++ b/packages/clarity-devtools/static/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "Microsoft Clarity Developer Tools",
   "description": "Clarity helps you understand how users are interacting with your website.",
-  "version": "0.8.63",
-  "version_name": "0.8.63",
+  "version": "0.8.64",
+  "version_name": "0.8.64",
   "minimum_chrome_version": "88",
   "devtools_page": "devtools.html",
   "icons": {

--- a/packages/clarity-js/package.json
+++ b/packages/clarity-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.8.63",
+  "version": "0.8.64",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/packages/clarity-js/src/core/version.ts
+++ b/packages/clarity-js/src/core/version.ts
@@ -1,2 +1,2 @@
-let version = "0.8.63";
+let version = "0.8.64";
 export default version;

--- a/packages/clarity-js/src/data/upload.ts
+++ b/packages/clarity-js/src/data/upload.ts
@@ -149,10 +149,28 @@ async function upload(final: boolean = false): Promise<void> {
     if(!envelope.data) return;
 
     let e = JSON.stringify(envelope.envelope(last));
-    let a = "[" + analysis.join() + "]";
 
-    let p = sendPlaybackBytes ? "[" + playback.join() + "]" : Constant.Empty;
-    
+    // Rotate buffers BEFORE serializing/awaiting compress.
+    // `await compress(payload)` below yields the event loop, during which concurrent
+    // queue() calls can run. If we snapshot-then-await-then-eassign (`analysis = []`), 
+    // those concurrent pushes land in the soon-to-be-orphaned array reference and are silently lost.
+    //  By swapping the bindings up front, the= pending arrays are local-only and concurrent pushes 
+    // land in the fresh module-level arrays, where they ride out in the next upload.
+    let pendingAnalysis = analysis;
+    analysis = [];
+
+    let pendingPlayback: string[] = [];
+    if (sendPlaybackBytes) {
+        pendingPlayback = playback;
+        playback = [];
+        playbackBytes = 0;
+        discoverBytes = 0;
+        leanLimit = false;
+    }
+
+    let a = "[" + pendingAnalysis.join() + "]";
+    let p = sendPlaybackBytes ? "[" + pendingPlayback.join() + "]" : Constant.Empty;
+
     // For final (beacon) payloads, If size is too large, we need to remove playback data
     if (last && p.length > 0 && (e.length + a.length + p.length > Setting.MaxBeaconPayloadBytes)) {
         p = Constant.Empty;
@@ -167,15 +185,6 @@ async function upload(final: boolean = false): Promise<void> {
     let zipped = last ? null : await compress(payload);
     metric.sum(Metric.TotalBytes, zipped ? zipped.length : payload.length);
     send(payload, zipped, envelope.data.sequence, last);
-
-    // Clear out events now that payload has been dispatched
-    analysis = [];
-    if (sendPlaybackBytes) {
-        playback = [];
-        playbackBytes = 0;
-        discoverBytes = 0;
-        leanLimit = false;
-    }
 }
 
 function stringify(encoded: EncodedPayload): string {

--- a/packages/clarity-js/src/data/upload.ts
+++ b/packages/clarity-js/src/data/upload.ts
@@ -152,14 +152,14 @@ async function upload(final: boolean = false): Promise<void> {
 
     // Rotate buffers BEFORE serializing/awaiting compress.
     // `await compress(payload)` below yields the event loop, during which concurrent
-    // queue() calls can run. If we snapshot-then-await-then-eassign (`analysis = []`), 
+    // queue() calls can run. If we snapshot-then-await-then-reassign (`analysis = []`),
     // those concurrent pushes land in the soon-to-be-orphaned array reference and are silently lost.
-    //  By swapping the bindings up front, the= pending arrays are local-only and concurrent pushes 
+    // By swapping the bindings up front, the pending arrays are local-only and concurrent pushes
     // land in the fresh module-level arrays, where they ride out in the next upload.
     let pendingAnalysis = analysis;
     analysis = [];
 
-    let pendingPlayback: string[] = [];
+    let pendingPlayback: string[];
     if (sendPlaybackBytes) {
         pendingPlayback = playback;
         playback = [];
@@ -169,7 +169,7 @@ async function upload(final: boolean = false): Promise<void> {
     }
 
     let a = "[" + pendingAnalysis.join() + "]";
-    let p = sendPlaybackBytes ? "[" + pendingPlayback.join() + "]" : Constant.Empty;
+    let p = sendPlaybackBytes ? "[" + pendingPlayback!.join() + "]" : Constant.Empty;
 
     // For final (beacon) payloads, If size is too large, we need to remove playback data
     if (last && p.length > 0 && (e.length + a.length + p.length > Setting.MaxBeaconPayloadBytes)) {

--- a/packages/clarity-visualize/package.json
+++ b/packages/clarity-visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-visualize",
-  "version": "0.8.63",
+  "version": "0.8.64",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.8.63"
+    "clarity-decode": "^0.8.64"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",


### PR DESCRIPTION
This pull request updates all Clarity packages and dependencies from version 0.8.63 to 0.8.64 and includes an important fix to the event upload logic to prevent data loss during concurrent uploads. The main focus is on improving reliability when handling event buffers.