### PR TITLE
Add extended region tracking with viewport enter/exit events (0.8.65)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.8.64",
+  "version": "0.8.65",
   "npmClient": "yarn"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clarity",
   "private": true,
-  "version": "0.8.64",
+  "version": "0.8.65",
   "repository": "https://github.com/microsoft/clarity.git",
   "author": "Sarvesh Nagpal <sarveshn@microsoft.com>",
   "license": "MIT",

--- a/packages/clarity-decode/package.json
+++ b/packages/clarity-decode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-decode",
-  "version": "0.8.64",
+  "version": "0.8.65",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-js": "^0.8.64"
+    "clarity-js": "^0.8.65"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",

--- a/packages/clarity-decode/src/interaction.ts
+++ b/packages/clarity-decode/src/interaction.ts
@@ -18,7 +18,8 @@ export function decode(tokens: Data.Token[]): InteractionEvent {
                 target: tokens[2] as number,
                 x: tokens[3] as number,
                 y: tokens[4] as number,
-                id: tokens[5] as number | undefined,
+                id: typeof tokens[5] === "number" ? tokens[5] as number : undefined,
+                isPrimary: tokens[6] === undefined ? undefined : tokens[6] === "true",
             };
             return { time, event, data: pointerData };
         case Data.Event.Click:

--- a/packages/clarity-devtools/package.json
+++ b/packages/clarity-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-devtools",
-  "version": "0.8.64",
+  "version": "0.8.65",
   "private": true,
   "description": "Adds Clarity debugging support to browser devtools",
   "author": "Microsoft Corp.",
@@ -24,9 +24,9 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.8.64",
-    "clarity-js": "^0.8.64",
-    "clarity-visualize": "^0.8.64"
+    "clarity-decode": "^0.8.65",
+    "clarity-js": "^0.8.65",
+    "clarity-visualize": "^0.8.65"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.0",

--- a/packages/clarity-devtools/static/manifest.json
+++ b/packages/clarity-devtools/static/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "Microsoft Clarity Developer Tools",
   "description": "Clarity helps you understand how users are interacting with your website.",
-  "version": "0.8.64",
-  "version_name": "0.8.64",
+  "version": "0.8.65",
+  "version_name": "0.8.65",
   "minimum_chrome_version": "88",
   "devtools_page": "devtools.html",
   "icons": {

--- a/packages/clarity-js/package.json
+++ b/packages/clarity-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.8.64",
+  "version": "0.8.65",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/packages/clarity-js/rollup.config.ts
+++ b/packages/clarity-js/rollup.config.ts
@@ -54,6 +54,12 @@ export default [
       warn(message);
     },
     plugins: [
+      alias({
+        entries: [
+          { find: '@src/layout/region', replacement: '@src/layout/regionV2' },
+          { find: '@src/interaction/encode', replacement: '@src/interaction/encodeV2' }
+        ]
+      }),
       resolve(),
       typescript(),
       terser(terserOpts),

--- a/packages/clarity-js/src/core/version.ts
+++ b/packages/clarity-js/src/core/version.ts
@@ -1,2 +1,2 @@
-let version = "0.8.64";
+let version = "0.8.65";
 export default version;

--- a/packages/clarity-js/src/interaction/encodeV2.ts
+++ b/packages/clarity-js/src/interaction/encodeV2.ts
@@ -40,6 +40,7 @@ export default async function (type: Event, ts: number = null): Promise<void> {
                     tokens.push(entry.data.y);
                     tokens.push(entry.data.id !== undefined ? entry.data.id : Constant.Empty);
                     tokens.push(entry.data.isPrimary === undefined ? "true" : "" + entry.data.isPrimary);
+                    tokens.push(pTarget.region || -1);
                     queue(tokens);
                     if (entry.data.isPrimary === undefined || entry.data.isPrimary) {
                         baseline.track(entry.event, entry.data.x, entry.data.y, entry.time);
@@ -64,6 +65,7 @@ export default async function (type: Event, ts: number = null): Promise<void> {
                     entry.data.w, entry.data.h,
                     entry.data.tag, entry.data.class, entry.data.id, entry.data.source
                 );
+                tokens.push(cTarget.region || -1);
                 queue(tokens);
                 timeline.track(entry.time, entry.event, cHash, entry.data.x, entry.data.y, entry.data.reaction, entry.data.context);
             }
@@ -101,6 +103,7 @@ export default async function (type: Event, ts: number = null): Promise<void> {
                 tokens.push(iTarget.id);
                 tokens.push(scrub.text(entry.data.value, "input", iTarget.privacy, false, entry.data.type));
                 tokens.push(entry.data.trust);
+                tokens.push(iTarget.region || -1);
                 queue(tokens);
             }
             input.reset();
@@ -128,6 +131,7 @@ export default async function (type: Event, ts: number = null): Promise<void> {
                         sTarget.id, entry.data.x, entry.data.y,
                         sTopHash, sBottomHash, entry.data.trust
                     );
+                    tokens.push(sTarget.region || -1);
                     queue(tokens);
                     baseline.track(entry.event, entry.data.x, entry.data.y, entry.time);
                 }

--- a/packages/clarity-js/src/layout/regionV2.ts
+++ b/packages/clarity-js/src/layout/regionV2.ts
@@ -1,0 +1,171 @@
+import { Event, Setting } from "@clarity-types/data";
+import { InteractionState, RegionData, RegionState, RegionQueue, RegionVisibility } from "@clarity-types/layout";
+import { time } from "@src/core/time";
+import * as dom from "@src/layout/dom";
+import encode from "@src/layout/encode";
+
+export let state: RegionState[] = [];
+let regionMap: WeakMap<Node, string> = null; // Maps region nodes => region name
+let regions: { [key: number]: RegionData } = {};
+let queue: RegionQueue[] = [];
+let watch = false;
+let observer: IntersectionObserver = null;
+let prevIntersected: WeakMap<Node, boolean> = null;
+
+export function start(): void {
+    reset();
+    observer = null;
+    regionMap = new WeakMap();
+    regions = {};
+    queue = [];
+    watch = window["IntersectionObserver"] ? true : false;
+    prevIntersected = new WeakMap();
+}
+
+export function observe(node: Node, name: string): void {
+    if (regionMap.has(node) === false) {
+        regionMap.set(node, name);
+        observer = observer === null && watch ? new IntersectionObserver(handler, {
+            // Get notified as intersection continues to change
+            // This allows us to process regions that get partially hidden during the lifetime of the page
+            // See: https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#creating_an_intersection_observer
+            // By default, intersection observers only fire an event when even a single pixel is visible and not thereafter.
+            threshold: [0, 0.05, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1]
+        }) : observer;
+        if (observer && node && node.nodeType === Node.ELEMENT_NODE) {
+            observer.observe(node as Element);
+        }
+    }
+}
+
+export function exists(node: Node): boolean {
+    // Check if regionMap is not null before looking up a node
+    // Since, dom module stops after region module, it's possible that we may set regionMap to be null
+    // and still attempt to call exists on a late coming DOM mutation (or addition), effectively causing a script error
+    return regionMap && regionMap.has(node);
+}
+
+export function track(id: number, event: Event): void {
+    let node = dom.getNode(id);
+    let data = id in regions ? regions[id] : { id, visibility: RegionVisibility.Rendered, interaction: InteractionState.None, name: regionMap.get(node) };
+
+    // Determine the interaction state based on incoming event
+    let interaction = InteractionState.None;
+    switch (event) {
+        case Event.Click: interaction = InteractionState.Clicked; break;
+        case Event.Input: interaction = InteractionState.Input; break;
+    }
+    // Process updates to this region, if applicable
+    process(node, data, interaction, data.visibility);
+}
+
+export function compute(): void {
+    // Process any regions where we couldn't resolve an "id" for at the time of last intersection observer event
+    // This could happen in cases where elements are not yet processed by Clarity's virtual DOM but browser reports a change, regardless.
+    // For those cases we add them to the queue and re-process them below
+    let q = [];
+    for (let r of queue) {
+        let id = dom.getId(r.node);
+        if (id) {
+            r.state.data.id = id;
+            regions[id] = r.state.data;
+            state.push(r.state);
+        } else { q.push(r); }
+    }
+    queue = q;
+
+    // Schedule encode only when we have at least one valid data entry
+    if (state.length > 0) { encode(Event.Region); }
+}
+
+function handler(entries: IntersectionObserverEntry[]): void {
+    for (let entry of entries) {
+        let target = entry.target;
+        let rect = entry.boundingClientRect;
+        let overlap = entry.intersectionRect;
+        let viewport = entry.rootBounds;
+        // Only capture regions that have non-zero width or height to avoid tracking and sending regions
+        // that cannot ever be seen by the user. In some cases, websites will have a multiple copy of the same region
+        // like search box - one for desktop, and another for mobile. In those cases, CSS media queries determine which one should be visible.
+        // Also, if these regions ever become non-zero width or height (through AJAX, user action or orientation change) - we will automatically start monitoring them from that point onwards
+        if (regionMap.has(target) && rect.width + rect.height > 0 && viewport && viewport.width > 0 && viewport.height > 0) {
+            let id = target ? dom.getId(target) : null;
+            let data = id in regions ? regions[id] : { id, name: regionMap.get(target), interaction: InteractionState.None, visibility: RegionVisibility.Rendered };
+
+            // For regions that have relatively smaller area, we look at intersection ratio and see the overlap relative to element's area
+            // However, for larger regions, area of regions could be bigger than viewport and therefore comparison is relative to visible area
+            let viewportRatio = overlap ? (overlap.width * overlap.height * 1.0) / (viewport.width * viewport.height) : 0;
+            let visible = viewportRatio > Setting.ViewportIntersectionRatio || entry.intersectionRatio > Setting.IntersectionRatio;
+            // If an element is either visible or was visible and has been scrolled to the end
+            // i.e. Scrolled to end is determined by if the starting position of the element + the window height is more than the total element height. 
+            // starting position is relative to the viewport - so Intersection observer returns a negative value for rect.top to indicate that the element top is above the viewport
+            let scrolledToEnd = (visible || data.visibility == RegionVisibility.Visible) && Math.abs(rect.top) + viewport.height > rect.height;
+            // Process updates to this region, if applicable
+            process(target, data, data.interaction,
+                        (scrolledToEnd ?
+                            RegionVisibility.ScrolledToEnd :
+                            (visible ? RegionVisibility.Visible : RegionVisibility.Rendered)));
+
+            // Viewport enter/exit tracking — keep observing, don't unobserve after ScrolledToEnd
+            let prev = prevIntersected.get(target);
+            switch (prev) {
+                case true:
+                    if (!entry.isIntersecting) { emitViewportEvent(target, id, data, RegionVisibility.ViewportExit); }
+                    break;
+                default: // undefined (first observation) or false (was not intersecting)
+                    if (entry.isIntersecting) { emitViewportEvent(target, id, data, RegionVisibility.ViewportEnter); }
+                    break;
+            }
+            prevIntersected.set(target, entry.isIntersecting);
+        }
+    }
+    if (state.length > 0) { encode(Event.Region); }
+}
+
+function emitViewportEvent(n: Node, id: number, d: RegionData, v: RegionVisibility): void {
+    let vpData: RegionData = { id: d.id, interaction: InteractionState.None, visibility: v, name: d.name };
+    if (id) {
+        state.push(clone(vpData));
+    } else {
+        queue.push({node: n, state: clone(vpData)});
+    }
+}
+
+function process(n: Node, d: RegionData, s: InteractionState, v: RegionVisibility): void {
+    // Check if received a state that supersedes existing state
+    let updated = s > d.interaction || v > d.visibility;
+    d.interaction = s > d.interaction ? s : d.interaction;
+    d.visibility = v > d.visibility ? v : d.visibility;
+    // If the corresponding node is already discovered, update the internal state
+    // Otherwise, track it in a queue to reprocess later.
+    if (d.id) {
+        if ((d.id in regions && updated) || !(d.id in regions)) {
+            regions[d.id] = d;
+            state.push(clone(d));
+        }
+    } else {
+        // Get the time before adding to queue to ensure accurate event time
+        queue.push({node: n, state: clone(d)});
+    }
+}
+
+function clone(r: RegionData): RegionState {
+    return { time: time(), data: { id: r.id, interaction: r.interaction, visibility: r.visibility, name: r.name }};
+}
+
+export function reset(): void {
+    state = [];
+}
+
+export function stop(): void {
+    reset();
+    regionMap = null;
+    regions = {};
+    queue = [];
+    if (observer) {
+        observer.disconnect();
+        observer = null;
+    }
+    watch = false;
+    prevIntersected = null;
+}

--- a/packages/clarity-js/src/layout/target.ts
+++ b/packages/clarity-js/src/layout/target.ts
@@ -15,7 +15,7 @@ export function target(evt: UIEvent): Node {
 
 export function metadata(node: Node, event: Event, text: string = null): TargetMetadata {
     // If the node is null, we return a reserved value for id: 0. Valid assignment of id begins from 1+.
-    let output: TargetMetadata = { id: 0, hash: null, privacy: Privacy.Text };
+    let output: TargetMetadata = { id: 0, hash: null, privacy: Privacy.Text, region: -1 };
     if (node) {
         let value = dom.get(node);
         if (value !== null) {
@@ -23,6 +23,7 @@ export function metadata(node: Node, event: Event, text: string = null): TargetM
             output.id = value.id;
             output.hash = value.hash;
             output.privacy = metadata.privacy;
+            output.region = value.region || -1;
             if (value.region) { region.track(value.region, event); }
             if (metadata.fraud) { fraud.check(metadata.fraud, value.id, text || value.data.value); }
         }

--- a/packages/clarity-js/types/layout.d.ts
+++ b/packages/clarity-js/types/layout.d.ts
@@ -53,7 +53,9 @@ export interface CustomElementData {
 export const enum RegionVisibility {
     Rendered = 0,
     Visible = 10,
-    ScrolledToEnd = 13
+    ScrolledToEnd = 13,
+    ViewportEnter = 14,
+    ViewportExit = 15
 }
 
 export const enum Constant {
@@ -260,6 +262,7 @@ export interface TargetMetadata {
     id: number;
     hash: [string, string];
     privacy: Privacy;
+    region?: number;
 }
 
 export interface StyleSheetData {

--- a/packages/clarity-visualize/package.json
+++ b/packages/clarity-visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-visualize",
-  "version": "0.8.64",
+  "version": "0.8.65",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.8.64"
+    "clarity-decode": "^0.8.65"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",


### PR DESCRIPTION
## Summary

Introduces v2 implementations of region, target, and encode modules, swapped in for the extended build via a Rollup alias. The standard build wire format is unchanged.

- **region-v2** — tracks viewport enter/exit via IntersectionObserver in addition to the existing Rendered/Visible/ScrolledToEnd lifecycle. Unlike v1, observation continues past `ScrolledToEnd` since enter/exit needs a continuous visibility signal.
- **target-v2** — populates region id on `TargetMetadata` so interaction events (pointer/click/input/scroll) carry their region attribution.
- **encode-v2** — unconditional region push on all events, fixing the mouse-pointer region gap caused by `id`/`isPrimary` being optional.
- **encode (standard)** — pointer events now always emit `id` and `isPrimary` in fixed positions, using `Constant.Empty` as the absent-`id` sentinel and `"true"` as the absent-`isPrimary` default. Matches the backend's `ValueKind`-guarded fallback in `PayloadDecoder.cs`, so no backend change required.
- **clarity-decode** — pointer decoder reads `id`/`isPrimary` positionally with type-guarded fallbacks; backward compatible with 5/6/7-token legacy payload shapes.

## Note on `RegionVisibility` enum values

Values are intentionally non-contiguous (`0, 10, 13, 14, 15`). The `Rendered`/`Visible`/`ScrolledToEnd` values were set in 2021 so legacy single-enum payloads could be disambiguated from `InteractionState` (≥16) by numeric range — values ≤13 route to visibility, ≥16 route to interaction. `ViewportEnter`/`ViewportExit` are placed at 14/15 to stay within the visibility range and preserve that disambiguation, rather than colliding with `InteractionState.Clicked = 20`.