### PR TITLE
Always free activeTask in scheduler to prevent stale-entry wedge

### DIFF
--- a/packages/clarity-js/src/core/task.ts
+++ b/packages/clarity-js/src/core/task.ts
@@ -64,16 +64,14 @@ function run(): void {
     if (entry) {
         activeTask = entry;
         entry.task().then((): void => {
-            // Bail out if the context in which this task was operating is different from the current page
-            // An example scenario where task could span across pages is Single Page Applications (SPA)
-            // A task that started on page #1, but completes on page #2
-            if (entry.id !== metadata.id()) { return; }
-            entry.resolve();
-            activeTask = null; // Reset active task back to null now that the promise is resolved
+            // Skip resolve() if the page context changed, but always free activeTask and drain
+            // the queue — otherwise a stale entry pins activeTask and wedges the scheduler.
+            let stale = entry.id !== metadata.id();
+            if (!stale) { entry.resolve(); }
+            activeTask = null;
             run();
         }).catch((error: Error): void => {
-            // If one of the scheduled tasks failed, log, recover and continue processing rest of the tasks
-            if (entry.id !== metadata.id()) { return; }
+            // Same invariant: always free activeTask and drain, regardless of page context.
             if (error) { internal.log(Code.RunTask, Severity.Warning, error.name, error.message, error.stack); }
             activeTask = null;
             run();

--- a/packages/clarity-js/src/core/task.ts
+++ b/packages/clarity-js/src/core/task.ts
@@ -72,7 +72,8 @@ function run(): void {
             run();
         }).catch((error: Error): void => {
             // Same invariant: always free activeTask and drain, regardless of page context.
-            if (error) { internal.log(Code.RunTask, Severity.Warning, error.name, error.message, error.stack); }
+            let stale = entry.id !== metadata.id();
+            if (!stale && error) { internal.log(Code.RunTask, Severity.Warning, error.name, error.message, error.stack); }
             activeTask = null;
             run();
         });


### PR DESCRIPTION
## Summary
- `run()` in `core/task.ts` returned early on a page-id mismatch in both `.then` and `.catch`, without releasing `activeTask` or calling `run()` again.
- That left `activeTask` permanently pinned to a completed entry, so every subsequent `task.schedule` call enqueued without ever draining — wedging the layout/mutation pipeline for the rest of the session.
- Fix: always reset `activeTask` and call `run()` in both branches. Still skip `entry.resolve()` for stale entries so awaiters do not proceed with results from a different page context.

## Why this matters
Symptoms when this triggered in the wild: initial snapshot uploads, then zero `Mutation`/`Discover` events for the rest of the session, while interaction handlers continue minting node IDs for elements that are never serialized. Replay shows a frozen initial DOM.