### PR TITLE
Fix UA-CH brand.name bug and clean up hints

### DIFF
--- a/packages/clarity-js/src/data/metadata.ts
+++ b/packages/clarity-js/src/data/metadata.ts
@@ -100,10 +100,12 @@ export function start(): void {
 function userAgentData(): void {
   let uaData = navigator["userAgentData"];
   if (uaData && uaData.getHighEntropyValues) {
-    uaData.getHighEntropyValues(["model", "platform", "platformVersion", "uaFullVersion"]).then(ua => {
+    // brands, mobile, and platform are low-entropy and always included in the response per
+    // UA-CH spec §3.1 (https://wicg.github.io/ua-client-hints/#getHighEntropyValues); only high-entropy hints need to be listed.
+    uaData.getHighEntropyValues(["model", "platformVersion"]).then(ua => {
       dimension.log(Dimension.Platform, ua.platform);
       dimension.log(Dimension.PlatformVersion, ua.platformVersion);
-      ua.brands?.forEach(brand => { dimension.log(Dimension.Brand, brand.name + Constant.Tilde + brand.version); });
+      ua.brands?.forEach(brand => { dimension.log(Dimension.Brand, brand.brand + Constant.Tilde + brand.version); });
       dimension.log(Dimension.Model, ua.model);
       metric.max(Metric.Mobile, ua.mobile ? BooleanFlag.True : BooleanFlag.False);
     });

--- a/test/uach.test.ts
+++ b/test/uach.test.ts
@@ -1,0 +1,152 @@
+import { test, expect } from "@playwright/test";
+import { readFileSync } from "fs";
+import { pathToFileURL } from "url";
+import { resolve } from "path";
+import { decode } from "clarity-decode";
+
+async function setupAndCollect(page: import("@playwright/test").Page) {
+    const htmlPath = resolve(__dirname, "./html/core.html");
+    const html = readFileSync(htmlPath, "utf8");
+    await page.goto(pathToFileURL(htmlPath).toString());
+
+    await page.setContent(html.replace("</body>", `
+        <script>
+          window.payloads = [];
+          window.uachData = null;
+
+          if (navigator.userAgentData && navigator.userAgentData.getHighEntropyValues) {
+            window.uachData = {
+              brands: navigator.userAgentData.brands.map(function(b) {
+                return { brand: b.brand, version: b.version };
+              }),
+              platform: navigator.userAgentData.platform,
+              mobile: navigator.userAgentData.mobile
+            };
+            navigator.userAgentData.getHighEntropyValues(
+              ["model", "platformVersion"]
+            ).then(function(ua) {
+              window.uachData.platformVersion = ua.platformVersion;
+              window.uachData.model = ua.model;
+            });
+          }
+
+          ${readFileSync(resolve(__dirname, "../packages/clarity-js/build/clarity.min.js"), "utf8")};
+          clarity("start", {
+            delay: 100,
+            content: true,
+            fraud: [],
+            regions: [],
+            mask: [],
+            unmask: [],
+            upload: function(payload) { window.payloads.push(payload); window.clarity("upgrade", "test"); },
+            projectId: "test"
+          });
+        </script>
+        </body>
+    `));
+
+    await page.hover("#two");
+    await page.click("#child");
+    await page.locator("#search").fill("");
+    await page.locator("#search").type("query");
+    await page.waitForFunction("payloads && payloads.length > 2");
+    await page.waitForFunction("window.uachData !== null && window.uachData.platformVersion !== undefined");
+
+    const uachData = await page.evaluate("window.uachData") as {
+        brands: { brand: string; version: string }[];
+        platform: string;
+        platformVersion: string;
+        model: string;
+        mobile: boolean;
+    };
+
+    const encoded: string[] = await page.evaluate("payloads");
+    const decoded = encoded.map(x => decode(x));
+
+    // Dimension keys: Platform=22, PlatformVersion=23, Brand=24, Model=25
+    // Metric keys: Mobile=27
+    const clarityBrands: string[] = [];
+    let clarityPlatform: string | undefined;
+    let clarityPlatformVersion: string | undefined;
+    let clarityModel: string | undefined;
+    let clarityMobile: number | undefined;
+    for (const payload of decoded) {
+        if (payload.dimension) {
+            for (const event of payload.dimension) {
+                if (event.data) {
+                    if (event.data[24]) { clarityBrands.push(...event.data[24]); }
+                    if (event.data[22]) { clarityPlatform = event.data[22][0]; }
+                    if (event.data[23]) { clarityPlatformVersion = event.data[23][0]; }
+                    if (event.data[25]) { clarityModel = event.data[25][0]; }
+                }
+            }
+        }
+        if (payload.metric) {
+            for (const event of payload.metric) {
+                if (event.data && event.data[27] !== undefined) { clarityMobile = event.data[27]; }
+            }
+        }
+    }
+
+    return { uachData, clarityBrands, clarityPlatform, clarityPlatformVersion, clarityModel, clarityMobile };
+}
+
+test.describe("UA-CH userAgentData", () => {
+
+    test("Brand dimension contains correct browser brand names", async ({ page }) => {
+        const { uachData, clarityBrands } = await setupAndCollect(page);
+
+        const realBrands = uachData.brands
+            .filter(b => /^(Chromium|Google Chrome|Chrome)$/i.test(b.brand))
+            .map(b => b.brand + "~" + b.version);
+
+        expect(realBrands.length).toBeGreaterThan(0);
+        expect(clarityBrands.length).toBeGreaterThan(0);
+
+        for (const expected of realBrands) {
+            expect(clarityBrands).toContain(expected);
+        }
+
+        for (const brand of clarityBrands) {
+            expect(brand).not.toMatch(/^undefined~/);
+        }
+    });
+
+    test("Brand dimension contains major-only versions, not full dotted versions", async ({ page }) => {
+        const { clarityBrands } = await setupAndCollect(page);
+
+        expect(clarityBrands.length).toBeGreaterThan(0);
+
+        for (const brand of clarityBrands) {
+            const version = brand.split("~")[1];
+            expect(version).toBeDefined();
+            expect(version).not.toContain(".");
+        }
+    });
+
+    test("Platform matches UA-CH platform", async ({ page }) => {
+        const { uachData, clarityPlatform } = await setupAndCollect(page);
+        expect(clarityPlatform).toBe(uachData.platform);
+    });
+
+    test("PlatformVersion matches UA-CH platformVersion", async ({ page }) => {
+        const { uachData, clarityPlatformVersion } = await setupAndCollect(page);
+        expect(clarityPlatformVersion).toBe(uachData.platformVersion);
+    });
+
+    test("Model matches UA-CH model", async ({ page }) => {
+        const { uachData, clarityModel } = await setupAndCollect(page);
+        if (uachData.model) {
+            expect(clarityModel).toBe(uachData.model);
+        } else {
+            // Desktop browsers return empty model; Clarity omits empty dimensions
+            expect(clarityModel).toBeUndefined();
+        }
+    });
+
+    test("Mobile metric matches UA-CH mobile", async ({ page }) => {
+        const { uachData, clarityMobile } = await setupAndCollect(page);
+        const expected = uachData.mobile ? 1 : 0;
+        expect(clarityMobile).toBe(expected);
+    });
+});

--- a/test/uach.test.ts
+++ b/test/uach.test.ts
@@ -1,55 +1,32 @@
 import { test, expect } from "@playwright/test";
-import { readFileSync } from "fs";
-import { pathToFileURL } from "url";
-import { resolve } from "path";
 import { decode } from "clarity-decode";
+import { markup } from "./helper";
+
+// Wire-protocol IDs mirrored from packages/clarity-js/types/data.d.ts.
+// clarity-decode declares Data.Dimension / Data.Metric as const enums (types-only),
+// so they have no runtime representation we can import here.
+const Dimension = { Platform: 22, PlatformVersion: 23, Brand: 24, Model: 25 } as const;
+const Metric = { Mobile: 27 } as const;
 
 async function setupAndCollect(page: import("@playwright/test").Page) {
-    const htmlPath = resolve(__dirname, "./html/core.html");
-    const html = readFileSync(htmlPath, "utf8");
-    await page.goto(pathToFileURL(htmlPath).toString());
-
-    await page.setContent(html.replace("</body>", `
-        <script>
-          window.payloads = [];
-          window.uachData = null;
-
-          if (navigator.userAgentData && navigator.userAgentData.getHighEntropyValues) {
-            window.uachData = {
-              brands: navigator.userAgentData.brands.map(function(b) {
-                return { brand: b.brand, version: b.version };
-              }),
-              platform: navigator.userAgentData.platform,
-              mobile: navigator.userAgentData.mobile
+    // Capture navigator.userAgentData ground truth before clarity loads.
+    await page.addInitScript(() => {
+        (window as any).uachData = null;
+        const ua = (navigator as any).userAgentData;
+        if (ua && ua.getHighEntropyValues) {
+            (window as any).uachData = {
+                brands: ua.brands.map((b: any) => ({ brand: b.brand, version: b.version })),
+                platform: ua.platform,
+                mobile: ua.mobile,
             };
-            navigator.userAgentData.getHighEntropyValues(
-              ["model", "platformVersion"]
-            ).then(function(ua) {
-              window.uachData.platformVersion = ua.platformVersion;
-              window.uachData.model = ua.model;
+            ua.getHighEntropyValues(["model", "platformVersion"]).then((hv: any) => {
+                (window as any).uachData.platformVersion = hv.platformVersion;
+                (window as any).uachData.model = hv.model;
             });
-          }
+        }
+    });
 
-          ${readFileSync(resolve(__dirname, "../packages/clarity-js/build/clarity.min.js"), "utf8")};
-          clarity("start", {
-            delay: 100,
-            content: true,
-            fraud: [],
-            regions: [],
-            mask: [],
-            unmask: [],
-            upload: function(payload) { window.payloads.push(payload); window.clarity("upgrade", "test"); },
-            projectId: "test"
-          });
-        </script>
-        </body>
-    `));
-
-    await page.hover("#two");
-    await page.click("#child");
-    await page.locator("#search").fill("");
-    await page.locator("#search").type("query");
-    await page.waitForFunction("payloads && payloads.length > 2");
+    const encoded = await markup(page, "core.html");
     await page.waitForFunction("window.uachData !== null && window.uachData.platformVersion !== undefined");
 
     const uachData = await page.evaluate("window.uachData") as {
@@ -60,11 +37,8 @@ async function setupAndCollect(page: import("@playwright/test").Page) {
         mobile: boolean;
     };
 
-    const encoded: string[] = await page.evaluate("payloads");
     const decoded = encoded.map(x => decode(x));
 
-    // Dimension keys: Platform=22, PlatformVersion=23, Brand=24, Model=25
-    // Metric keys: Mobile=27
     const clarityBrands: string[] = [];
     let clarityPlatform: string | undefined;
     let clarityPlatformVersion: string | undefined;
@@ -74,16 +48,16 @@ async function setupAndCollect(page: import("@playwright/test").Page) {
         if (payload.dimension) {
             for (const event of payload.dimension) {
                 if (event.data) {
-                    if (event.data[24]) { clarityBrands.push(...event.data[24]); }
-                    if (event.data[22]) { clarityPlatform = event.data[22][0]; }
-                    if (event.data[23]) { clarityPlatformVersion = event.data[23][0]; }
-                    if (event.data[25]) { clarityModel = event.data[25][0]; }
+                    if (event.data[Dimension.Brand]) { clarityBrands.push(...event.data[Dimension.Brand]); }
+                    if (event.data[Dimension.Platform]) { clarityPlatform = event.data[Dimension.Platform][0]; }
+                    if (event.data[Dimension.PlatformVersion]) { clarityPlatformVersion = event.data[Dimension.PlatformVersion][0]; }
+                    if (event.data[Dimension.Model]) { clarityModel = event.data[Dimension.Model][0]; }
                 }
             }
         }
         if (payload.metric) {
             for (const event of payload.metric) {
-                if (event.data && event.data[27] !== undefined) { clarityMobile = event.data[27]; }
+                if (event.data && event.data[Metric.Mobile] !== undefined) { clarityMobile = event.data[Metric.Mobile]; }
             }
         }
     }

--- a/test/uach.test.ts
+++ b/test/uach.test.ts
@@ -131,7 +131,12 @@ test.describe("UA-CH userAgentData", () => {
 
     test("PlatformVersion matches UA-CH platformVersion", async ({ page }) => {
         const { uachData, clarityPlatformVersion } = await setupAndCollect(page);
-        expect(clarityPlatformVersion).toBe(uachData.platformVersion);
+        if (uachData.platformVersion) {
+            expect(clarityPlatformVersion).toBe(uachData.platformVersion);
+        } else {
+            // Headless/Linux browsers return empty platformVersion; dimension.log skips empty strings
+            expect(clarityPlatformVersion).toBeUndefined();
+        }
     });
 
     test("Model matches UA-CH model", async ({ page }) => {


### PR DESCRIPTION
## Summary

- **Fix `brand.name` → `brand.brand`**: The `NavigatorUABrandVersion` objects in the UA-CH `brands` array have a `brand` property, not `name`. The old code read `brand.name` (which is `undefined`), causing every Chromium-based session to log `"undefined~VERSION"` in the Brand dimension instead of the actual browser name.
- **Remove deprecated `uaFullVersion` hint** that was requested but never read from the response.
- **Remove redundant `platform` from hints** — it's a low-entropy property always included in the response per UA-CH spec §3.1.
- **Add Playwright tests** verifying all UA-CH-captured properties (brand, platform, platformVersion, model, mobile) against real browser ground-truth values.

## MDN documentation

From [NavigatorUAData: brands property](https://developer.mozilla.org/en-US/docs/Web/API/NavigatorUAData/brands), the brand object properties are:

> `brand`
> A string containing the brand. For example, `"Google Chrome"`.
>
> `version`
> A string containing the version. For example, `"91"`.

There is no `name` property. The existing code reads `brand.name`, which resolves to `undefined` via JavaScript's standard property lookup on an object that lacks that key.

## Test plan

- [x] `npx playwright test test/uach.test.ts --project=e2e` — 6 tests pass
- [ ] Verify Brand dimension in decoded payloads shows `"Google Chrome~VERSION"` / `"Chromium~VERSION"` instead of `"undefined~VERSION"`
- [ ] Verify fallback path (browsers without UA-CH like Firefox/Safari) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)