### PR TITLE
Fix instanceof Text breakage in same-origin iframes (#1049)

### DIFF
--- a/packages/clarity-js/src/layout/mutation.ts
+++ b/packages/clarity-js/src/layout/mutation.ts
@@ -51,7 +51,29 @@ export function observe(node: Document | ShadowRoot): void {
   try {
 
     let m = api(Constant.MutationObserver);
-    let observer = m in window ? new window[m](measure(handle) as MutationCallback) : null;
+    // For same-origin iframe documents, host the MutationObserver and its callback in the
+    // iframe's own realm. Otherwise, a parent-realm callback reading record.addedNodes[i]
+    // causes Chrome to materialize the iframe's node wrappers in the parent realm, which
+    // breaks `instanceof Text` (and similar identity checks) inside the iframe.
+    // See https://github.com/microsoft/clarity/issues/1049
+    let view = (node as Document).defaultView as any;
+    let target: any = view && view !== window && m in view ? view : window;
+    let callback: MutationCallback;
+    if (target === window) {
+      callback = measure(handle) as MutationCallback;
+    } else {
+      target.__clr = target.__clr || {};
+      target.__clr.handle = measure(handle);
+      try {
+        // Function constructor produces a function in the iframe's realm.
+        callback = new target.Function("r", "this.__clr.handle(r);").bind(target);
+      } catch {
+        // Strict CSP can block Function(); preserve existing behavior in that case.
+        target = window;
+        callback = measure(handle) as MutationCallback;
+      }
+    }
+    let observer = m in target ? new target[m](callback) : null;
     if (observer) {
       observer.observe(node, { attributes: true, childList: true, characterData: true, subtree: true });
       observedNodes.set(node, observer);
@@ -60,7 +82,7 @@ export function observe(node: Document | ShadowRoot): void {
     if (node['defaultView']) {
       proxyStyleRules(node['defaultView']);
     }
-    
+
   } catch (e) {
     internal.log(Code.MutationObserver, Severity.Info, e ? e.name : null);
   }

--- a/test/html/iframe-text-1049.html
+++ b/test/html/iframe-text-1049.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html><body>
+  <iframe id="f" name="iframe-1" srcdoc="<html><body><h1 id='h'>Hello, world!</h1></body></html>"></iframe>
+  <script>
+    window.checks = function(label){
+      const f = document.getElementById('f');
+      const idoc = f.contentDocument;
+      const iwin = f.contentWindow;
+      const h1 = idoc.getElementById('h');
+      const tn = h1 ? h1.firstChild : null;
+      return {
+        label: label,
+        tnVal: tn && tn.nodeValue,
+        instanceofTextIframe: tn instanceof iwin.Text,
+        instanceofTextParent: tn instanceof window.Text,
+        ctorIsIframeText: tn && tn.constructor === iwin.Text,
+        protoMatch: tn && Object.getPrototypeOf(tn) === iwin.Text.prototype
+      };
+    };
+    window.editAsHtml = function(){
+      const f = document.getElementById('f');
+      const idoc = f.contentDocument;
+      const h1 = idoc.getElementById('h');
+      h1.outerHTML = "<h1 id='h'>Edited text!</h1>";
+    };
+  </script>
+</body></html>

--- a/test/iframe-instanceof-1049.spec.ts
+++ b/test/iframe-instanceof-1049.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { pathToFileURL } from 'url';
+
+const CLARITY_MIN = readFileSync(resolve(__dirname, '../packages/clarity-js/build/clarity.min.js'), 'utf8');
+const HTML_PATH = resolve(__dirname, './html/iframe-text-1049.html');
+
+// Regression test for https://github.com/microsoft/clarity/issues/1049
+// Before the fix, Clarity's parent-realm MutationObserver callback observing an
+// iframe document caused Chrome to wrap iframe nodes in the parent realm. That
+// broke `node instanceof Text` (and similar identity checks) inside the iframe
+// for any text node that came in through a mutation record (outerHTML/innerHTML
+// edits, Quill rich-text manipulation, DevTools "Edit as HTML", etc.).
+test('issue #1049: iframe text nodes stay instance of iframe Text after mutations', async ({ page }) => {
+  await page.goto(pathToFileURL(HTML_PATH).toString());
+  await page.waitForFunction(() => {
+    const f = document.getElementById('f') as HTMLIFrameElement | null;
+    return !!(f && f.contentDocument && f.contentDocument.getElementById('h'));
+  });
+
+  await page.addScriptTag({ content: `window.payloads = []; ${CLARITY_MIN}` });
+  await page.evaluate(() => (window as any).clarity('start', {
+    projectId: 'test',
+    delay: 50,
+    content: true,
+    fraud: [],
+    regions: [],
+    mask: [],
+    unmask: [],
+    upload: (payload: string) => { (window as any).payloads.push(payload); }
+  }));
+  await page.waitForTimeout(500);
+
+  // Edit iframe content (simulates DevTools "Edit as HTML" or Quill outerHTML).
+  await page.evaluate(() => (window as any).editAsHtml());
+  await page.waitForTimeout(100);
+
+  const fromParent = await page.evaluate(() => (window as any).checks('after-edit'));
+  expect(fromParent.instanceofTextIframe, 'text node should still be instance of iframe Text').toBe(true);
+  expect(fromParent.ctorIsIframeText, 'constructor should be iframe Text').toBe(true);
+  expect(fromParent.protoMatch, 'prototype chain should still point at iframe Text.prototype').toBe(true);
+
+  // Also verify from the iframe's own realm, mirroring how Quill / DevTools
+  // console see the node.
+  const fromIframe = await page.evaluate(() => {
+    const f = document.getElementById('f') as HTMLIFrameElement;
+    const idoc = f.contentDocument!;
+    const iwin = f.contentWindow as any;
+    const script = idoc.createElement('script');
+    script.textContent = `
+      var h1 = document.getElementById('h');
+      var tn = h1 ? h1.firstChild : null;
+      window.__iframeCheck = {
+        tnVal: tn ? tn.nodeValue : null,
+        instanceofText: tn instanceof Text,
+        ctorIsText: tn ? tn.constructor === Text : null
+      };
+    `;
+    idoc.body.appendChild(script);
+    return iwin.__iframeCheck;
+  });
+  expect(fromIframe.instanceofText, 'instanceof Text inside iframe should be true').toBe(true);
+  expect(fromIframe.ctorIsText, 'constructor === Text inside iframe should be true').toBe(true);
+});


### PR DESCRIPTION
**Summary**
Fixes [#1049](https://github.com/microsoft/clarity/issues/1049). With Clarity enabled, node instanceof Text returns false inside same-origin iframes for text nodes created via outerHTML/innerHTML (Quill, DevTools "Edit as HTML", dangerouslySetInnerHTML, etc.).
Root cause: Clarity attached a parent-realm MutationObserver + callback to the iframe document. When the callback indexed record.addedNodes[i], Chrome materialized those iframe nodes' JS wrappers in the parent realm and cached them — so subsequent instanceof iframeWindow.Text checks (including inside the iframe itself) returned false.
Fix: host both the MutationObserver and its callback in the iframe's own realm. The callback (created via the iframe's Function constructor) just trampolines back into Clarity's existing handle function in the parent. Because the first hand to touch record.addedNodes[i] is now iframe-realm code, the wrappers stay iframe-realm. If strict CSP blocks the Function() constructor, the code falls back to the current behavior — no regression.
