### PR TITLE
fix(clarity-js): prevent history proxy stack overflow on Chrome for iOS (CriOS)

### DIFF
--- a/packages/clarity-js/src/core/history.ts
+++ b/packages/clarity-js/src/core/history.ts
@@ -8,11 +8,11 @@ import * as metric from "@src/data/metric";
 let pushState = null;
 let replaceState = null;
 let url = null;
-let count = 0;
+let depth = 0;
 
 export function start(): void {
     url = getCurrentUrl();
-    count = 0;
+    depth = 0;
     bind(window, "popstate", compute);
     pushState = proxyHistory(pushState, "pushState");
     replaceState = proxyHistory(replaceState, "replaceState");
@@ -23,8 +23,19 @@ function proxyHistory(original: Function, method: string): Function {
         try {
             original = history[method];
             history[method] = function(): void {
-                original.apply(this, arguments);
-                if (core.active() && check()) {
+                // Cap re-entrancy so a foreign history wrapper (e.g. Chrome for iOS) that
+                // re-enters this proxy can't recurse until the stack overflows.
+                if (depth >= Setting.CallStackDepth) {
+                    internal.log(Code.CallStackDepth, Severity.Info);
+                    return;
+                }
+                depth++;
+                try {
+                    original.apply(this, arguments);
+                } finally {
+                    depth--;
+                }
+                if (core.active()) {
                     compute();
                 }
             };
@@ -36,16 +47,7 @@ function proxyHistory(original: Function, method: string): Function {
     return original;
 }
 
-function check(): boolean {
-    if (count++ > Setting.CallStackDepth) {
-        internal.log(Code.CallStackDepth, Severity.Info);
-        return false;
-    }
-    return true;
-}
-
 function compute(): void {
-    count = 0; // Reset the counter
     if (url !== getCurrentUrl()) {
         // If the url changed, start tracking it as a new page
         clarity.stop();
@@ -64,5 +66,5 @@ function getCurrentUrl(): string {
 
 export function stop(): void {
     url = null;
-    count = 0;
+    depth = 0;
 }

--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -1,0 +1,83 @@
+import { test, expect } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { pathToFileURL } from 'url';
+import { decode } from 'clarity-decode';
+
+// Loads Clarity on a page whose history.pushState is already wrapped by a foreign
+// script, reproducing the Chrome for iOS (CriOS) scenario where the injected wrapper
+// re-dispatches through the live history.pushState. Once Clarity wraps that wrapper the
+// two call each other; the re-entrancy guard must cap the depth and log
+// Code.CallStackDepth instead of throwing RangeError: Maximum call stack size exceeded.
+test.describe('History Tests', () => {
+    test('should cap re-entrant history proxy recursion instead of overflowing the stack', async ({ page }) => {
+        await page.addInitScript(() => {
+            const nativePush = history.pushState;
+            (window as any).__criosActive = false;
+            history.pushState = function (this: History): void {
+                if ((window as any).__criosActive) {
+                    // Re-dispatch through the current property (Clarity's wrapper after start).
+                    return (history.pushState as Function).apply(this, arguments);
+                }
+                return nativePush.apply(this, arguments);
+            };
+        });
+
+        const htmlPath = resolve(__dirname, './html/core.html');
+        const html = readFileSync(htmlPath, 'utf8');
+        const clarityJs = readFileSync(resolve(__dirname, '../packages/clarity-js/build/clarity.min.js'), 'utf8');
+        await page.goto(pathToFileURL(htmlPath).toString());
+        await page.setContent(html.replace('</body>', `
+            <script>
+              window.payloads = [];
+              ${clarityJs};
+              clarity("start", { delay: 100, projectId: "test", upload: (p) => { window.payloads.push(p); window.clarity("upgrade", "test"); } });
+            </script>
+            </body>
+        `));
+
+        await page.waitForFunction('window.payloads && window.payloads.length > 0', null, { timeout: 10000 });
+        const initialCount = await page.evaluate('window.payloads.length') as number;
+
+        // Trigger the mutual recursion and confirm the page survives (no RangeError).
+        const threw = await page.evaluate(() => {
+            (window as any).__criosActive = true;
+            try {
+                history.pushState({}, "");
+                return false;
+            } catch (e) {
+                return (e as Error)?.name === "RangeError";
+            } finally {
+                (window as any).__criosActive = false;
+            }
+        });
+        expect(threw).toBe(false);
+
+        // Diagnostic logs are queued with transmit=false, so they piggyback on the next
+        // upload. Perform an interaction to flush the pending Code.CallStackDepth log.
+        await page.click('#child');
+
+        await page.waitForFunction(
+            (count) => window.payloads && window.payloads.length > count,
+            initialCount,
+            { timeout: 10000 }
+        );
+
+        const allPayloads = await page.evaluate('window.payloads') as string[];
+        const decoded = allPayloads.map((x: string) => decode(x));
+
+        let foundCallStackLog = false;
+        for (const payload of decoded) {
+            if (payload.log) {
+                for (const log of payload.log) {
+                    if (log.data?.code === 4) { // Code.CallStackDepth = 4
+                        foundCallStackLog = true;
+                        expect(log.data.severity).toBe(0); // Severity.Info = 0
+                    }
+                }
+            }
+        }
+
+        expect(foundCallStackLog).toBe(true);
+    });
+});


### PR DESCRIPTION
Fixes # `RangeError: Maximum call stack size exceeded` thrown only on Chrome for iOS (CriOS).1103 

**Cause:** `core/history.ts` proxies `history.pushState`/`replaceState`. CriOS injects its own history wrapper; when it re-enters Clarity's proxy the two wrappers call each other until the stack overflows. The existing `CallStackDepth` guard only gated `compute()` (and reset its counter every navigation), so the real re-entry  `original. was never protected.apply` point 

**Fix:** track re-entrancy `depth` around `original.apply`. Normal navigations are unchanged; once depth reaches `Setting.CallStackDepth` the proxy stops calling `original` and logs `Code.CallStackDepth`, so the stack can't overflow. Removes the now-redundant `check()`/`count`.

**Testing:** `yarn build` passes; `yarn tslint` adds no new findings in `history.ts`.
