### PR TITLE
fix(upload): guard against envelope.data being null after async compress await

### DIFF
--- a/packages/clarity-js/src/data/upload.ts
+++ b/packages/clarity-js/src/data/upload.ts
@@ -183,6 +183,9 @@ async function upload(final: boolean = false): Promise<void> {
     // In all other cases, we continue to send back string value
     let payload = stringify(encoded);
     let zipped = last ? null : await compress(payload);
+    // Guard: stop() may have been called while compress() was awaiting (async race condition).
+    // envelope.stop() sets envelope.data = null, so we must re-check before accessing envelope.data.sequence.
+    if (!envelope.data) { return; }
     metric.sum(Metric.TotalBytes, zipped ? zipped.length : payload.length);
     send(payload, zipped, envelope.data.sequence, last);
 }
@@ -300,7 +303,7 @@ function done(sequence: number): void {
 function delay(): number {
     // Progressively increase delay as we continue to send more payloads from the client to the server
     // If we are not uploading data to a server, and instead invoking UploadCallback, in that case keep returning configured value
-    let gap = config.lean === false && discoverBytes > 0 ? Setting.MinUploadDelay : envelope.data.sequence * config.delay;
+    let gap = config.lean === false && discoverBytes > 0 ? Setting.MinUploadDelay : (envelope.data ? envelope.data.sequence * config.delay : Setting.MinUploadDelay);
     return typeof config.upload === Constant.String ? Math.max(Math.min(gap, Setting.MaxUploadDelay), Setting.MinUploadDelay) : config.delay;
 }
 

--- a/packages/clarity-js/src/data/upload.ts
+++ b/packages/clarity-js/src/data/upload.ts
@@ -303,7 +303,9 @@ function done(sequence: number): void {
 function delay(): number {
     // Progressively increase delay as we continue to send more payloads from the client to the server
     // If we are not uploading data to a server, and instead invoking UploadCallback, in that case keep returning configured value
-    let gap = config.lean === false && discoverBytes > 0 ? Setting.MinUploadDelay : (envelope.data ? envelope.data.sequence * config.delay : Setting.MinUploadDelay);
+    let gap = config.lean === false && discoverBytes > 0
+        ? Setting.MinUploadDelay
+        : (envelope.data ? envelope.data.sequence * config.delay : Setting.MinUploadDelay);
     return typeof config.upload === Constant.String ? Math.max(Math.min(gap, Setting.MaxUploadDelay), Setting.MinUploadDelay) : config.delay;
 }
 


### PR DESCRIPTION
## Problem

`upload()` is an `async` function. After the `await compress(payload)` call, the JS event loop is yielded. During that window a page navigation can trigger `clarity.stop()`, which calls `envelope.stop()` and sets `envelope.data = null`.

When the microtask resumes, the very next line:

```ts
send(payload, zipped, envelope.data.sequence, last);
//            ^^^^^^^^^^^^^^^^^^^ 💥 TypeError: Cannot read properties of null (reading 'sequence')
```

throws an unhandled promise rejection that Angular's Zone.js surfaces as an error.

The existing guard added by #894 (`if (!envelope.data) return;`) is placed **before** the `await` and therefore does not cover this post-`await` window.

This error is reproducible on Angular SPAs with frequent route transitions where Clarity flushes data at the moment the user navigates away.

## Fix

**1. Add a second null guard in `upload()` immediately after the `await`:**

```ts
let zipped = last ? null : await compress(payload);
// Guard: stop() may have been called while compress() was awaiting (async race condition).
// envelope.stop() sets envelope.data = null, so we must re-check before accessing envelope.data.sequence.
if (!envelope.data) { return; }
metric.sum(Metric.TotalBytes, zipped ? zipped.length : payload.length);
send(payload, zipped, envelope.data.sequence, last);
```

**2. Add a null guard in `delay()`** which also reads `envelope.data.sequence` without any prior null check:

```ts
// Before:
let gap = ... : envelope.data.sequence * config.delay;

// After:
let gap = ... : (envelope.data ? envelope.data.sequence * config.delay : Setting.MinUploadDelay);
```

## Root cause diagram

```
upload() starts           stop() fires during navigation
     │                           │
     ▼                           │
if (!envelope.data) return  ←  ✅ check passes, data is set
     │                           │
     ▼                           │
await compress(payload)  ─────── yields event loop ──────► envelope.stop() → data = null
     │                                                            │
     ▼                                                            │
metric.sum(...)                                                   │
send(..., envelope.data.sequence, ...)  ◄──── data is NULL here ─┘
                 💥 TypeError
```
