### PR TITLE
Fix consent API failing to delete domain-scoped cookies

### DIFF
--- a/packages/clarity-js/src/data/cookie.ts
+++ b/packages/clarity-js/src/data/cookie.ts
@@ -57,8 +57,35 @@ export function setCookie(key: string, value: string, time: number): void {
     expiry.setDate(expiry.getDate() + time);
     let expires = expiry ? Constant.Expires + expiry.toUTCString() : Constant.Empty;
     let cookie = key + "=" + encodedValue + Constant.Semicolon + expires + Constant.Path;
+
+    // When clearing a cookie (empty value) we must not write any new cookie, because storing
+    // information on the device without consent is not permitted, and consent may already be denied
+    // by the time we clear. We also cannot rely on the cached root domain here: when a deletion is
+    // the first cookie operation in this runtime, the domain is still undiscovered. Instead, issue
+    // the deletion on the current host and on every writable parent domain. A deletion is an
+    // already-expired cookie, so it stores nothing and can be attempted broadly; the browser simply
+    // ignores domains we are not allowed to write to (e.g. public suffixes). This guarantees an
+    // existing domain-scoped cookie (e.g. _clck on .example.com) is removed from subdomains without
+    // needing to discover the domain first. See issue #1105.
+    if (value === Constant.Empty) {
+      // Delete the host-only cookie.
+      document.cookie = cookie;
+      let hostname = location.hostname ? location.hostname.split(Constant.Dot) : [];
+      let domain = Constant.Empty;
+      // Walk backwards, accumulating parent-domain suffixes (.com -> .example.com -> ...), and delete
+      // on each. We skip the absolute last part, e.g. .com or .net, which is never a writable domain.
+      for (let i = hostname.length - 1; i >= 0; i--) {
+        domain = Constant.Dot + hostname[i] + domain;
+        if (i < hostname.length - 1) {
+          document.cookie = cookie + Constant.Semicolon + Constant.Domain + domain;
+        }
+      }
+      return;
+    }
+
     try {
       // Attempt to get the root domain only once and fall back to writing cookie on the current domain.
+      // This only runs for writes, which happen when config.track is true (i.e. consent is granted).
       if (rootDomain === null) {
         let hostname = location.hostname ? location.hostname.split(Constant.Dot) : [];
         // Walk backwards on a domain and attempt to set a cookie, until successful

--- a/packages/clarity-js/test/cookie.test.ts
+++ b/packages/clarity-js/test/cookie.test.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+/**
+ * Cookie domain deletion tests - loads the built clarity.min.js in a browser and verifies
+ * that domain-scoped cookies can be deleted even when the first cookie operation in a runtime
+ * is a deletion (empty value).
+ *
+ * Regression test for issue #1105: revoking consent failed to delete an existing domain-scoped
+ * _clck cookie on multi-label hosts (e.g. app.example.com). Root-domain discovery used to verify
+ * success by reading back the written value, which can never match for a deletion, poisoning the
+ * cached root domain to empty and leaving the domain-scoped cookie undeletable. Deletions now
+ * target the current host and every writable parent domain instead of depending on discovery.
+ */
+
+// Use the minified browser build which exposes window.clarity.
+const clarityJsPath = join(__dirname, "../build/clarity.min.js");
+
+// A multi-label host is required so cookie domain scoping is exercised (localhost won't trigger it).
+const HOST = "http://app.example.com/";
+
+test.describe("cookie - domain-scoped deletion", () => {
+    let clarityJs: string;
+
+    test.beforeAll(() => {
+        // Load the build artifact once. Doing this here (rather than at module load) keeps a missing
+        // artifact from crashing test discovery and reports it as a normal test failure instead.
+        clarityJs = readFileSync(clarityJsPath, "utf-8");
+    });
+
+    test("deletes an existing domain-scoped _clck cookie when consent is revoked", async ({ context }) => {
+        // Fake the multi-label host by fulfilling every request with a minimal HTML page.
+        await context.route("**/*", async (route) => {
+            await route.fulfill({ status: 200, contentType: "text/html", body: "<!DOCTYPE html><html><head></head><body>x</body></html>" });
+        });
+        const page = await context.newPage();
+        await page.goto(HOST);
+
+        // Simulate a PRIOR Clarity runtime that wrote a VALID, fresh, domain-scoped _clck at
+        // .example.com. It must be a valid granted Clarity cookie so that on start track() finds it
+        // fresh and skips re-writing it, leaving the internal rootDomain cache uninitialized - this
+        // is the exact condition under which the bug manifested.
+        await page.evaluate(() => {
+            const end36 = Math.ceil((Date.now() + 365 * 86400000) / 86400000).toString(36);
+            // format: userId ^ cookieVersion(2) ^ endDays(base36) ^ consent(1=granted) ^ dob(0)
+            const clck = ["testuser", "2", end36, "1", "0"].join("^");
+            document.cookie = "_clck=" + clck + ";path=/;domain=.example.com";
+        });
+
+        const before: string = await page.evaluate(() => document.cookie);
+        expect(/(^|;)\s*_clck=/.test(before)).toBe(true);
+
+        // Load Clarity and, in the SAME runtime, start then immediately revoke consent so that the
+        // first setCookie call is a deletion (the reported scenario).
+        await page.evaluate((code) => { eval(code); }, clarityJs);
+        await page.evaluate(() => {
+            (window as any).clarity("start", { projectId: "test", upload: false });
+            (window as any).clarity("consentv2", { analytics_Storage: "denied", ad_Storage: "denied" });
+        });
+
+        // Wait until the domain-scoped _clck cookie has been removed, rather than relying on a fixed
+        // delay which is timing-dependent and flaky across CI environments.
+        await expect
+            .poll(() => page.evaluate(() => document.cookie), { timeout: 5000 })
+            .not.toMatch(/(^|;)\s*_clck=/);
+    });
+});


### PR DESCRIPTION
Updated the approach based on a compliance concern with the previous probe-based discovery.
Why the change: the earlier version discovered the writable root domain by writing a throwaway  _clcp  probe cookie. But domain discovery runs during cookie deletion too (consent revoke →  clear(true)  →  setCookie(_clck, "", 0) ), which means it would write a cookie while consent is denied. Under the ePrivacy Directive (Art. 5(3)), the regulated act is storing information on the device, independent of the cookie's content — so writing even an empty/throwaway probe without consent is not permitted.

New approach (no cookie ever written under denied consent):
• Deletions no longer discover the domain. They issue the delete (an already-expired cookie, which stores nothing) on the current host and every writable parent-domain suffix. The browser ignores domains we can't write to (e.g. public suffixes), so this reliably removes a domain-scoped  _clck / _clsk  without needing the cache — fixing the deletion-first scenario in #1105.
• Writes (only when consent is granted,  config.track === true ) keep the original readback-based discovery, unchanged.
This drops the  _clcp  constant and the probe entirely.
Review comments addressed in the regression test: artifact loaded in  beforeAll ,  route  handler is  async /awaits  fulfill , and the fixed  setTimeout  is replaced with  expect.poll .

Fixes #1105