### PR TITLE
fix(scripts): size check ignores version arg (unset $PREV_VERSION)

### DIFF
--- a/scripts/check-file-size.sh
+++ b/scripts/check-file-size.sh
@@ -33,8 +33,8 @@ TEMP_DIR=$(mktemp -d)
 pushd $TEMP_DIR > /dev/null
 
 # Download previous version from npm
-echo "Downloading previous version $PREV_VERSION..."
-npm pack $PACKAGE_NAME@$PREV_VERSION > /dev/null 2>&1
+echo "Downloading previous version $PREVIOUS_VERSION..."
+npm pack $PACKAGE_NAME@$PREVIOUS_VERSION > /dev/null 2>&1
 
 PREV_PACKAGE=$(find . -name "*.tgz" | head -1)
 


### PR DESCRIPTION
check-file-size.sh stores the version in $PREVIOUS_VERSION but downloads with the never-assigned $PREV_VERSION, so npm pack resolves to latest and the size comparison is always against the wrong package. Fixed to use $PREVIOUS_VERSION.