### PR TITLE
Add configurable restart delay(0.8.69)

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -2,6 +2,6 @@
   "packages": [
     "packages/*"
   ],
-  "version": "0.8.68",
+  "version": "0.8.69",
   "npmClient": "yarn"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "clarity",
   "private": true,
-  "version": "0.8.68",
+  "version": "0.8.69",
   "repository": "git+https://github.com/microsoft/clarity.git",
   "author": "Sarvesh Nagpal <sarveshn@microsoft.com>",
   "license": "MIT",

--- a/packages/clarity-decode/package.json
+++ b/packages/clarity-decode/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-decode",
-  "version": "0.8.68",
+  "version": "0.8.69",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -26,7 +26,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-js": "^0.8.68"
+    "clarity-js": "^0.8.69"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",

--- a/packages/clarity-devtools/package.json
+++ b/packages/clarity-devtools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-devtools",
-  "version": "0.8.68",
+  "version": "0.8.69",
   "private": true,
   "description": "Adds Clarity debugging support to browser devtools",
   "author": "Microsoft Corp.",
@@ -24,9 +24,9 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.8.68",
-    "clarity-js": "^0.8.68",
-    "clarity-visualize": "^0.8.68"
+    "clarity-decode": "^0.8.69",
+    "clarity-js": "^0.8.69",
+    "clarity-visualize": "^0.8.69"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.0",

--- a/packages/clarity-devtools/static/manifest.json
+++ b/packages/clarity-devtools/static/manifest.json
@@ -2,8 +2,8 @@
   "manifest_version": 3,
   "name": "Microsoft Clarity Developer Tools",
   "description": "Clarity helps you understand how users are interacting with your website.",
-  "version": "0.8.68",
-  "version_name": "0.8.68",
+  "version": "0.8.69",
+  "version_name": "0.8.69",
   "minimum_chrome_version": "88",
   "devtools_page": "devtools.html",
   "icons": {

--- a/packages/clarity-js/package.json
+++ b/packages/clarity-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-js",
-  "version": "0.8.68",
+  "version": "0.8.69",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",

--- a/packages/clarity-js/src/core/config.ts
+++ b/packages/clarity-js/src/core/config.ts
@@ -1,4 +1,5 @@
 import { Config, Time } from "@clarity-types/core";
+import { Setting } from "@clarity-types/data";
 
 let config: Config = {
     projectId: null,
@@ -26,6 +27,7 @@ let config: Config = {
     includeSubdomains: true,
     modules: [],
     diagnostics: false,
+    restart: Setting.RestartDelay,
 };
 
 export default config;

--- a/packages/clarity-js/src/core/history.ts
+++ b/packages/clarity-js/src/core/history.ts
@@ -1,6 +1,7 @@
 import { BooleanFlag, Code, Constant, Metric, Setting, Severity } from "@clarity-types/data";
 import * as clarity from "@src/clarity";
 import * as core from "@src/core"
+import config from "@src/core/config";
 import { bind } from "@src/core/event";
 import * as internal from "@src/diagnostic/internal";
 import * as metric from "@src/data/metric";
@@ -51,7 +52,7 @@ function compute(): void {
     if (url !== getCurrentUrl()) {
         // If the url changed, start tracking it as a new page
         clarity.stop();
-        window.setTimeout(restart, Setting.RestartDelay);
+        window.setTimeout(restart, config.restart);
     }
 }
 

--- a/packages/clarity-js/src/core/history.ts
+++ b/packages/clarity-js/src/core/history.ts
@@ -1,6 +1,6 @@
 import { BooleanFlag, Code, Constant, Metric, Setting, Severity } from "@clarity-types/data";
 import * as clarity from "@src/clarity";
-import * as core from "@src/core"
+import * as core from "@src/core";
 import config from "@src/core/config";
 import { bind } from "@src/core/event";
 import * as internal from "@src/diagnostic/internal";
@@ -52,7 +52,7 @@ function compute(): void {
     if (url !== getCurrentUrl()) {
         // If the url changed, start tracking it as a new page
         clarity.stop();
-        window.setTimeout(restart, config.restart);
+        window.setTimeout(restart, config.restart ?? Setting.RestartDelay);
     }
 }
 

--- a/packages/clarity-js/src/core/version.ts
+++ b/packages/clarity-js/src/core/version.ts
@@ -1,2 +1,2 @@
-let version = "0.8.68";
+let version = "0.8.69";
 export default version;

--- a/packages/clarity-js/types/core.d.ts
+++ b/packages/clarity-js/types/core.d.ts
@@ -142,6 +142,7 @@ export interface Config {
     includeSubdomains?: boolean;
     modules?: string[];
     diagnostics?: boolean;
+    restart?: number;
 }
 
 export const enum Constant {

--- a/packages/clarity-visualize/package.json
+++ b/packages/clarity-visualize/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clarity-visualize",
-  "version": "0.8.68",
+  "version": "0.8.69",
   "description": "An analytics library that uses web page interactions to generate aggregated insights",
   "author": "Microsoft Corp.",
   "license": "MIT",
@@ -27,7 +27,7 @@
     "url": "https://github.com/Microsoft/clarity/issues"
   },
   "dependencies": {
-    "clarity-decode": "^0.8.68"
+    "clarity-decode": "^0.8.69"
   },
   "devDependencies": {
     "@rollup/plugin-commonjs": "^24.0.0",

--- a/test/history.test.ts
+++ b/test/history.test.ts
@@ -80,4 +80,73 @@ test.describe('History Tests', () => {
 
         expect(foundCallStackLog).toBe(true);
     });
+
+    // Verifies the configurable SPA restart delay: on a URL change, history.ts schedules the
+    // restart via window.setTimeout(restart, config.restart). We spy on setTimeout and assert
+    // the recorded delay matches the value passed to clarity("start", ...).
+    test('should schedule the SPA restart using the configured restart delay', async ({ page }) => {
+        const htmlPath = resolve(__dirname, './html/core.html');
+        const html = readFileSync(htmlPath, 'utf8');
+        const clarityJs = readFileSync(resolve(__dirname, '../packages/clarity-js/build/clarity.min.js'), 'utf8');
+        await page.goto(pathToFileURL(htmlPath).toString());
+        await page.setContent(html.replace('</body>', `
+            <script>
+              window.payloads = [];
+              window.__timeoutDelays = [];
+              const __nativeSetTimeout = window.setTimeout;
+              window.setTimeout = function (handler, timeout) {
+                if (typeof timeout === 'number') { window.__timeoutDelays.push(timeout); }
+                return __nativeSetTimeout.apply(this, arguments);
+              };
+              ${clarityJs};
+              clarity("start", { delay: 100, restart: 1234, projectId: "test", upload: (p) => { window.payloads.push(p); window.clarity("upgrade", "test"); } });
+            </script>
+            </body>
+        `));
+
+        await page.waitForFunction('window.payloads && window.payloads.length > 0', null, { timeout: 10000 });
+
+        await page.evaluate(() => {
+            (window as any).__timeoutDelays.length = 0;
+            history.pushState({}, "", location.pathname + "?spa=" + Date.now());
+        });
+
+        await page.waitForFunction(() => (window as any).__timeoutDelays.includes(1234), null, { timeout: 5000 });
+        const delays = await page.evaluate(() => (window as any).__timeoutDelays) as number[];
+        expect(delays).toContain(1234);
+    });
+
+    // Regression guard: passing restart: undefined must not zero-out the delay (setTimeout would
+    // otherwise treat undefined as 0 and restart immediately). It must fall back to the 250ms default.
+    test('should fall back to the default restart delay when restart is undefined', async ({ page }) => {
+        const htmlPath = resolve(__dirname, './html/core.html');
+        const html = readFileSync(htmlPath, 'utf8');
+        const clarityJs = readFileSync(resolve(__dirname, '../packages/clarity-js/build/clarity.min.js'), 'utf8');
+        await page.goto(pathToFileURL(htmlPath).toString());
+        await page.setContent(html.replace('</body>', `
+            <script>
+              window.payloads = [];
+              window.__timeoutDelays = [];
+              const __nativeSetTimeout = window.setTimeout;
+              window.setTimeout = function (handler, timeout) {
+                if (typeof timeout === 'number') { window.__timeoutDelays.push(timeout); }
+                return __nativeSetTimeout.apply(this, arguments);
+              };
+              ${clarityJs};
+              clarity("start", { delay: 100, restart: undefined, projectId: "test", upload: (p) => { window.payloads.push(p); window.clarity("upgrade", "test"); } });
+            </script>
+            </body>
+        `));
+
+        await page.waitForFunction('window.payloads && window.payloads.length > 0', null, { timeout: 10000 });
+
+        await page.evaluate(() => {
+            (window as any).__timeoutDelays.length = 0;
+            history.pushState({}, "", location.pathname + "?spa=" + Date.now());
+        });
+
+        await page.waitForFunction(() => (window as any).__timeoutDelays.includes(250), null, { timeout: 5000 });
+        const delays = await page.evaluate(() => (window as any).__timeoutDelays) as number[];
+        expect(delays).toContain(250);
+    });
 });


### PR DESCRIPTION
Makes the single-page-app restart delay configurable via a new optional `restart` config option, instead of the hardcoded `Setting.RestartDelay`.

When the URL changes on a SPA (history `pushState`/`replaceState`/`popstate`), `core/history.ts` stops Clarity and restarts it after a short delay. That delay was hardcoded to 250ms; it now comes from `config.restart`.
